### PR TITLE
feat(CODEOWNERS): Add security as owner to vercel.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code Owners file
+/.github/CODEOWNERS @getsentry/security
+
+# Requiring review from security team for Content-Security-Policy changes
+/vercel.json @getsentry/security


### PR DESCRIPTION
Content Security Policy is defined in vercel.json and we rely on CSP to prevent unwanted trackers and cookies from getting dropped on our public websites. 
Adding security team as codeowners to prevent unwanted changes to the content security policy.
