### PR TITLE
chore: Enable sentry runtime metrics

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,6 +6,7 @@ Sentry.init({
   tracesSampleRate: 1,
   environment: process.env.NODE_ENV,
   integrations: [
+    Sentry.nodeRuntimeMetricsIntegration(),
     Sentry.prismaIntegration({
       prismaInstrumentation: new PrismaInstrumentation(),
     }),


### PR DESCRIPTION
enables https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/noderuntimemetrics/