### PR TITLE
feat: redesign changelog UI to match blog-astro style

### DIFF
--- a/src/app/api/changelog/[slug]/markdown/route.ts
+++ b/src/app/api/changelog/[slug]/markdown/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prismaClient } from "@/server/prisma-client";
 
+export const revalidate = 3600;
+
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> },
@@ -37,6 +39,7 @@ export async function GET(
   return new NextResponse(markdown, {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
     },
   });
 }

--- a/src/app/api/changelog/[slug]/markdown/route.ts
+++ b/src/app/api/changelog/[slug]/markdown/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { prismaClient } from "@/server/prisma-client";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export async function GET(
   _request: Request,

--- a/src/app/api/changelog/[slug]/markdown/route.ts
+++ b/src/app/api/changelog/[slug]/markdown/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { prismaClient } from "@/server/prisma-client";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+
+  const changelog = await prismaClient.changelog.findUnique({
+    where: { slug, published: true },
+    select: { title: true, content: true, publishedAt: true },
+  });
+
+  if (!changelog) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const date = changelog.publishedAt
+    ? changelog.publishedAt.toISOString().split("T")[0]
+    : "";
+
+  const markdown = [
+    `# ${changelog.title}`,
+    "",
+    date ? `Published: ${date}` : "",
+    date ? "" : null,
+    `Source: https://sentry.io/changelog/${slug}`,
+    "",
+    "---",
+    "",
+    changelog.content ?? "",
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+
+  return new NextResponse(markdown, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/src/app/api/changelog/markdown/route.ts
+++ b/src/app/api/changelog/markdown/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { prismaClient } from "@/server/prisma-client";
 
-export const revalidate = 300;
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   const changelogs = await prismaClient.changelog.findMany({

--- a/src/app/api/changelog/markdown/route.ts
+++ b/src/app/api/changelog/markdown/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { prismaClient } from "@/server/prisma-client";
+
+export async function GET() {
+  const changelogs = await prismaClient.changelog.findMany({
+    where: { published: true },
+    orderBy: { publishedAt: "desc" },
+    take: 20,
+    select: { title: true, slug: true, summary: true, publishedAt: true },
+  });
+
+  const lines: string[] = [
+    "# Sentry Changelog",
+    "",
+    "Source: https://sentry.io/changelog/",
+    "",
+    "---",
+    "",
+  ];
+
+  for (const entry of changelogs) {
+    const date = entry.publishedAt
+      ? entry.publishedAt.toISOString().split("T")[0]
+      : "";
+    const url = `https://sentry.io/changelog/${entry.slug}`;
+    lines.push(`## [${entry.title}](${url})`);
+    if (date) lines.push(`Published: ${date}`);
+    lines.push("");
+    if (entry.summary) lines.push(entry.summary.trim(), "");
+    lines.push("---", "");
+  }
+
+  return new NextResponse(lines.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/src/app/api/changelog/markdown/route.ts
+++ b/src/app/api/changelog/markdown/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prismaClient } from "@/server/prisma-client";
 
+export const revalidate = 300;
+
 export async function GET() {
   const changelogs = await prismaClient.changelog.findMany({
     where: { published: true },
@@ -31,6 +33,9 @@ export async function GET() {
   }
 
   return new NextResponse(lines.join("\n"), {
-    headers: { "Content-Type": "text/plain; charset=utf-8" },
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+    },
   });
 }

--- a/src/app/changelog/[slug]/loading.tsx
+++ b/src/app/changelog/[slug]/loading.tsx
@@ -2,11 +2,9 @@ import { LoadingArticle } from "@/client/components/article";
 
 export default function Loading() {
   return (
-    <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto grid grid-cols-12 bg-gray-200">
-      <div className="col-span-12 md:col-start-3 md:col-span-8">
-        <div className="max-w-3xl mx-auto px-4 p-4 sm:px-6 lg:px-8 mt-16">
-          <LoadingArticle />
-        </div>
+    <div className="bg-white min-h-screen">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8">
+        <LoadingArticle variant="light" />
       </div>
     </div>
   );

--- a/src/app/changelog/[slug]/page.tsx
+++ b/src/app/changelog/[slug]/page.tsx
@@ -7,8 +7,11 @@ import { getServerSession } from "next-auth/next";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { Suspense } from "react";
 
-import { Article } from "@/client/components/article";
+import { ShareButtons } from "@/client/components/shareButtons";
+import { TableOfContents } from "@/client/components/tableOfContents";
+import { CategoryTag } from "@/client/components/tag";
 import ArticleFooter from "@/client/components/articleFooter";
+import { DateComponent } from "@/client/components/date";
 import { authOptions } from "@/server/authOptions";
 import { mdxOptions } from "@/server/mdxOptions";
 import { prismaClient } from "@/server/prisma-client";
@@ -43,12 +46,8 @@ const getChangelog = unstable_cache(
   async (slug) => {
     try {
       return await prismaClient.changelog.findUnique({
-        where: {
-          slug,
-        },
-        include: {
-          categories: true,
-        },
+        where: { slug },
+        include: { categories: true },
       });
     } catch (_e) {
       return null;
@@ -58,17 +57,43 @@ const getChangelog = unstable_cache(
   { tags: ["changelog-detail"] },
 );
 
+const getRecentChangelogs = unstable_cache(
+  async (excludeSlug: string) => {
+    try {
+      return await prismaClient.changelog.findMany({
+        where: { published: true, slug: { not: excludeSlug } },
+        include: { categories: true },
+        orderBy: { publishedAt: "desc" },
+        take: 3,
+      });
+    } catch (_e) {
+      return [];
+    }
+  },
+  ["changelog-related"],
+  { tags: ["changelogs"] },
+);
+
+function estimateReadTime(content: string | null | undefined): string {
+  if (!content) return "";
+  const words = content.trim().split(/\s+/).length;
+  const minutes = Math.max(1, Math.round(words / 200));
+  return `${minutes} min read`;
+}
+
 export default async function ChangelogEntry(props: {
   params: Promise<{ slug: string }>;
 }) {
   const params = await props.params;
-  const changelog = await getChangelog(params.slug);
+  const [changelog, relatedEntries] = await Promise.all([
+    getChangelog(params.slug),
+    getRecentChangelogs(params.slug),
+  ]);
 
   if (!changelog) {
     notFound();
   }
 
-  // Don't show unpublished changelog entries
   if (!changelog.published) {
     const session = await getServerSession(authOptions);
     if (!session) {
@@ -76,53 +101,148 @@ export default async function ChangelogEntry(props: {
     }
   }
 
+  const readTime = estimateReadTime(changelog.content);
+
   return (
-    <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto grid grid-cols-12 bg-gray-200">
-      <div className="col-span-12 md:col-start-3 md:col-span-8">
-        <div className="max-w-3xl mx-auto px-4 p-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center space-x-4 py-3">
-            <Link href="/changelog/">
-              <button
-                className="flex items-center gap-2 px-6 py-3 font-bold text-center text-primary uppercase align-middle transition-all rounded-lg select-none hover:bg-gray-900/10 active:bg-gray-900/20"
-                type="button"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth="2"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                  className="w-4 h-4"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
-                  />
-                </svg>
-                Back
-              </button>
-            </Link>
-          </div>
-          <Article
-            title={changelog?.title}
-            image={changelog?.image}
-            date={changelog?.publishedAt}
+    <div className="bg-white min-h-screen">
+      {/* Full-bleed hero image */}
+      {changelog.image && (
+        // biome-ignore lint/performance/noImgElement: next/image doesn't resolve here
+        <img
+          src={changelog.image}
+          alt={changelog.title ?? ""}
+          className="w-full max-h-[480px] object-cover"
+        />
+      )}
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8">
+        {/* Back link */}
+        <Link
+          href="/changelog/"
+          className="inline-flex items-center gap-1.5 text-sm text-blog-muted hover:text-blog-accent transition-colors duration-150 mb-6"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-4 h-4"
+            aria-hidden="true"
           >
-            <Suspense fallback="Loading...">
-              <MDXRemote
-                source={changelog?.content || "No content found."}
-                options={
-                  {
-                    mdxOptions,
-                  } as any
-                }
-              />
-            </Suspense>
-          </Article>
-          <ArticleFooter />
+            <path
+              fillRule="evenodd"
+              d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z"
+              clipRule="evenodd"
+            />
+          </svg>
+          Changelog
+        </Link>
+
+        {/* Two-column layout: content + TOC */}
+        <div className="lg:grid lg:grid-cols-[1fr_220px] lg:gap-12">
+          {/* Main content */}
+          <div>
+            {/* Category tags */}
+            {changelog.categories.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-4">
+                {changelog.categories.map((cat) => (
+                  <CategoryTag key={cat.id} text={cat.name} />
+                ))}
+              </div>
+            )}
+
+            {/* Title */}
+            <h1 className="text-3xl sm:text-4xl font-bold text-blog-text leading-tight mb-4">
+              {changelog.title}
+            </h1>
+
+            {/* Metadata strip */}
+            <div className="flex items-center gap-4 pb-6 border-b border-blog-border mb-6">
+              {changelog.publishedAt && (
+                <span className="text-sm text-blog-muted">
+                  <DateComponent date={changelog.publishedAt} />
+                </span>
+              )}
+              {readTime && (
+                <>
+                  <span className="text-blog-border" aria-hidden="true">·</span>
+                  <span className="text-sm text-blog-muted">{readTime}</span>
+                </>
+              )}
+              <div className="ml-auto">
+                <ShareButtons
+                  title={changelog.title ?? ""}
+                  slug={changelog.slug}
+                />
+              </div>
+            </div>
+
+            {/* MDX body */}
+            <div className="prose prose-lg max-w-none blog-prose blog-content">
+              <Suspense fallback="Loading...">
+                <MDXRemote
+                  source={changelog.content ?? "No content found."}
+                  options={{ mdxOptions } as any}
+                />
+              </Suspense>
+            </div>
+
+            {/* Footer CTA */}
+            <div className="mt-12">
+              <ArticleFooter />
+            </div>
+          </div>
+
+          {/* Sticky TOC sidebar */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-8">
+              <TableOfContents contentSelector=".blog-content" />
+            </div>
+          </aside>
         </div>
+
+        {/* Related entries */}
+        {relatedEntries.length > 0 && (
+          <section className="mt-16 pt-10 border-t border-blog-border">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-blog-muted mb-6">
+              Recent entries
+            </h2>
+            <div className="grid sm:grid-cols-3 gap-5">
+              {relatedEntries.map((entry) => (
+                <Link
+                  key={entry.id}
+                  href={`/changelog/${entry.slug}`}
+                  className="group block bg-white border border-blog-border rounded-xl overflow-hidden hover:shadow-md transition-shadow duration-200"
+                >
+                  {entry.image && (
+                    // biome-ignore lint/performance/noImgElement: next/image doesn't resolve here
+                    <img
+                      src={entry.image}
+                      alt={entry.title ?? ""}
+                      className="w-full aspect-video object-cover"
+                    />
+                  )}
+                  <div className="p-4">
+                    {entry.categories.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mb-2">
+                        {entry.categories.map((cat) => (
+                          <CategoryTag key={cat.id} text={cat.name} />
+                        ))}
+                      </div>
+                    )}
+                    <h3 className="text-sm font-semibold text-blog-text group-hover:text-blog-accent transition-colors duration-150 line-clamp-2">
+                      {entry.title}
+                    </h3>
+                    {entry.publishedAt && (
+                      <p className="mt-2 text-xs text-blog-muted">
+                        <DateComponent date={entry.publishedAt} />
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/app/changelog/[slug]/page.tsx
+++ b/src/app/changelog/[slug]/page.tsx
@@ -164,9 +164,11 @@ export default async function ChangelogEntry(props: {
               )}
               {readTime && (
                 <>
-                  <span className="text-blog-border" aria-hidden="true">
-                    ·
-                  </span>
+                  {changelog.publishedAt && (
+                    <span className="text-blog-border" aria-hidden="true">
+                      ·
+                    </span>
+                  )}
                   <span className="text-sm text-blog-muted">{readTime}</span>
                 </>
               )}

--- a/src/app/changelog/[slug]/page.tsx
+++ b/src/app/changelog/[slug]/page.tsx
@@ -6,12 +6,11 @@ import { notFound } from "next/navigation";
 import { getServerSession } from "next-auth/next";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { Suspense } from "react";
-
+import ArticleFooter from "@/client/components/articleFooter";
+import { DateComponent } from "@/client/components/date";
 import { ShareButtons } from "@/client/components/shareButtons";
 import { TableOfContents } from "@/client/components/tableOfContents";
 import { CategoryTag } from "@/client/components/tag";
-import ArticleFooter from "@/client/components/articleFooter";
-import { DateComponent } from "@/client/components/date";
 import { authOptions } from "@/server/authOptions";
 import { mdxOptions } from "@/server/mdxOptions";
 import { prismaClient } from "@/server/prisma-client";
@@ -164,7 +163,9 @@ export default async function ChangelogEntry(props: {
               )}
               {readTime && (
                 <>
-                  <span className="text-blog-border" aria-hidden="true">·</span>
+                  <span className="text-blog-border" aria-hidden="true">
+                    ·
+                  </span>
                   <span className="text-sm text-blog-muted">{readTime}</span>
                 </>
               )}

--- a/src/app/changelog/[slug]/page.tsx
+++ b/src/app/changelog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { getServerSession } from "next-auth/next";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { Suspense } from "react";
 import ArticleFooter from "@/client/components/articleFooter";
+import { CopyPageButton } from "@/client/components/copyPageButton";
 import { DateComponent } from "@/client/components/date";
 import { ShareButtons } from "@/client/components/shareButtons";
 import { TableOfContents } from "@/client/components/tableOfContents";
@@ -169,7 +170,12 @@ export default async function ChangelogEntry(props: {
                   <span className="text-sm text-blog-muted">{readTime}</span>
                 </>
               )}
-              <div className="ml-auto">
+              <div className="ml-auto flex items-center gap-2">
+                <CopyPageButton
+                  title={changelog.title ?? ""}
+                  slug={changelog.slug}
+                  content={changelog.content ?? ""}
+                />
                 <ShareButtons
                   title={changelog.title ?? ""}
                   slug={changelog.slug}

--- a/src/app/changelog/header.tsx
+++ b/src/app/changelog/header.tsx
@@ -7,12 +7,12 @@ export default function Header({ loading }: { loading?: boolean }) {
         <h1 className="text-4xl font-medium text-white tracking-tight">
           Changelog
         </h1>
-        <div className="mt-2 flex items-center justify-between gap-4">
+        <div className="mt-2 flex items-start justify-between gap-4">
           <p className="text-white/60 text-base">
             Stay up to date on everything big and small, from product updates to
             SDK changes.
           </p>
-          <div className="flex-shrink-0 flex items-center gap-3">
+          <div className="flex-shrink-0 flex flex-col-reverse sm:flex-row items-end sm:items-center gap-2 sm:gap-3">
             {!loading && <CopyChangelogButton />}
             <a
               href="/changelog/feed.xml"

--- a/src/app/changelog/header.tsx
+++ b/src/app/changelog/header.tsx
@@ -3,18 +3,16 @@ import { CopyChangelogButton } from "@/client/components/copyChangelogButton";
 export default function Header({ loading }: { loading?: boolean }) {
   return (
     <div className={`w-full bg-darkPurple ${loading ? "animate-pulse" : ""}`}>
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-4xl font-medium text-white tracking-tight">
-              Changelog
-            </h1>
-            <p className="mt-2 text-white/60 text-base">
-              Stay up to date on everything big and small, from product updates
-              to SDK changes.
-            </p>
-          </div>
-          <div className="flex-shrink-0 mt-1 flex items-center gap-3">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-10">
+        <h1 className="text-4xl font-medium text-white tracking-tight">
+          Changelog
+        </h1>
+        <div className="mt-2 flex items-center justify-between gap-4">
+          <p className="text-white/60 text-base">
+            Stay up to date on everything big and small, from product updates to
+            SDK changes.
+          </p>
+          <div className="flex-shrink-0 flex items-center gap-3">
             {!loading && <CopyChangelogButton />}
             <a
               href="/changelog/feed.xml"

--- a/src/app/changelog/header.tsx
+++ b/src/app/changelog/header.tsx
@@ -1,15 +1,13 @@
 export default function Header({ loading }: { loading?: boolean }) {
   return (
-    <div
-      className={`w-full bg-white border-b border-blog-border ${loading ? "animate-pulse" : ""}`}
-    >
+    <div className={`w-full bg-darkPurple ${loading ? "animate-pulse" : ""}`}>
       <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="text-4xl font-bold text-blog-text tracking-tight">
+            <h1 className="text-4xl font-medium text-white tracking-tight">
               Changelog
             </h1>
-            <p className="mt-2 text-blog-muted text-base">
+            <p className="mt-2 text-white/60 text-base">
               Stay up to date on everything big and small, from product updates
               to SDK changes.
             </p>
@@ -17,7 +15,7 @@ export default function Header({ loading }: { loading?: boolean }) {
           <a
             href="/changelog/feed.xml"
             aria-label="Subscribe to RSS feed"
-            className="flex-shrink-0 mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-blog-accent border border-blog-accent hover:bg-blog-accent hover:text-white transition-colors duration-150"
+            className="flex-shrink-0 mt-1 inline-flex items-center gap-1.5 text-[#fd44b0] text-sm font-semibold uppercase hover:opacity-80 transition-opacity duration-150"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/app/changelog/header.tsx
+++ b/src/app/changelog/header.tsx
@@ -1,3 +1,5 @@
+import { CopyChangelogButton } from "@/client/components/copyChangelogButton";
+
 export default function Header({ loading }: { loading?: boolean }) {
   return (
     <div className={`w-full bg-darkPurple ${loading ? "animate-pulse" : ""}`}>
@@ -12,23 +14,26 @@ export default function Header({ loading }: { loading?: boolean }) {
               to SDK changes.
             </p>
           </div>
-          <a
-            href="/changelog/feed.xml"
-            aria-label="Subscribe to RSS feed"
-            className="flex-shrink-0 mt-1 inline-flex items-center gap-1.5 text-[#fd44b0] text-sm font-semibold uppercase hover:opacity-80 transition-opacity duration-150"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-3.5 h-3.5"
-              aria-hidden="true"
+          <div className="flex-shrink-0 mt-1 flex items-center gap-3">
+            {!loading && <CopyChangelogButton />}
+            <a
+              href="/changelog/feed.xml"
+              aria-label="Subscribe to RSS feed"
+              className="inline-flex items-center gap-1.5 text-[#fd44b0] text-sm font-semibold uppercase hover:opacity-80 transition-opacity duration-150"
             >
-              <path d="M3.75 3a.75.75 0 00-.75.75v.5c0 .414.336.75.75.75H4c6.075 0 11 4.925 11 11v.25c0 .414.336.75.75.75h.5a.75.75 0 00.75-.75V16C17 8.82 11.18 3 4 3h-.25z" />
-              <path d="M3 8.75A.75.75 0 013.75 8H4a8 8 0 018 8v.25a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75V16a6 6 0 00-6-6h-.25A.75.75 0 013 9.25v-.5zM7 15a2 2 0 11-4 0 2 2 0 014 0z" />
-            </svg>
-            RSS
-          </a>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-3.5 h-3.5"
+                aria-hidden="true"
+              >
+                <path d="M3.75 3a.75.75 0 00-.75.75v.5c0 .414.336.75.75.75H4c6.075 0 11 4.925 11 11v.25c0 .414.336.75.75.75h.5a.75.75 0 00.75-.75V16C17 8.82 11.18 3 4 3h-.25z" />
+                <path d="M3 8.75A.75.75 0 013.75 8H4a8 8 0 018 8v.25a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75V16a6 6 0 00-6-6h-.25A.75.75 0 013 9.25v-.5zM7 15a2 2 0 11-4 0 2 2 0 014 0z" />
+              </svg>
+              RSS
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/changelog/header.tsx
+++ b/src/app/changelog/header.tsx
@@ -1,44 +1,38 @@
-import Image from "next/image";
-import heroImage from "../../../public/img/hero.png";
-
 export default function Header({ loading }: { loading?: boolean }) {
   return (
-    <div className="w-full mx-auto h-96 relative bg-darkPurple">
-      <div className="relative w-full lg:max-w-7xl mx-auto px-4 lg:px-8 pt-8 grid grid-cols-12 items-center">
-        <Image
-          className={`justify-self-center col-span-10 hidden lg:block ${
-            loading ? "animate-fade-in-left" : ""
-          }`}
-          src={heroImage}
-          alt="Sentry Changelog Illustration"
-          height={273}
-          width={450}
-        />
-        <div
-          className={`relative col-span-12 mt-32 lg:absolute lg:w-96 lg:right-1/4 lg:-bottom-2 ${
-            loading ? "animate-fade-in-right" : ""
-          }`}
-        >
-          <h1 className="justify-self-center text-white font-bold text-4xl text-center lg:text-left mb-2">
-            Sentry Changelog
-          </h1>
-          <h2 className="justify-self-center text-gold text-1xl text-center lg:text-left">
-            Follow&nbsp;
-            <a
-              href="https://twitter.com/SentryChangelog"
-              target="_blank"
-              rel="noreferrer"
-              className="underline underline-offset-2"
+    <div
+      className={`w-full bg-white border-b border-blog-border ${loading ? "animate-pulse" : ""}`}
+    >
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-4xl font-bold text-blog-text tracking-tight">
+              Changelog
+            </h1>
+            <p className="mt-2 text-blog-muted text-base">
+              Stay up to date on everything big and small, from product updates
+              to SDK changes.
+            </p>
+          </div>
+          <a
+            href="/changelog/feed.xml"
+            aria-label="Subscribe to RSS feed"
+            className="flex-shrink-0 mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-blog-accent border border-blog-accent hover:bg-blog-accent hover:text-white transition-colors duration-150"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-3.5 h-3.5"
+              aria-hidden="true"
             >
-              <span className="sr-only">Twitter</span>
-              @SentryChangelog
-            </a>
-            &nbsp;to stay up to date on everything from product updates to SDK
-            changes.
-          </h2>
+              <path d="M3.75 3a.75.75 0 00-.75.75v.5c0 .414.336.75.75.75H4c6.075 0 11 4.925 11 11v.25c0 .414.336.75.75.75h.5a.75.75 0 00.75-.75V16C17 8.82 11.18 3 4 3h-.25z" />
+              <path d="M3 8.75A.75.75 0 013.75 8H4a8 8 0 018 8v.25a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75V16a6 6 0 00-6-6h-.25A.75.75 0 013 9.25v-.5zM7 15a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+            RSS
+          </a>
         </div>
       </div>
-      <div className="hero-bottom-left-down-slope absolute -bottom-0.5 w-full h-10 bg-gray-200 border-none" />
     </div>
   );
 }

--- a/src/app/changelog/layout.tsx
+++ b/src/app/changelog/layout.tsx
@@ -30,13 +30,15 @@ export default async function ChangelogLayout({
 
   return (
     <Fragment>
-      <NextTopLoader color="#8d5494" />
-      <div className="font-sans">
+      <NextTopLoader color="#6A5FC1" showSpinner={false} />
+      <div className="font-sans bg-white min-h-screen flex flex-col">
         <GlobalHeader menuItems={menuItems} mode="dark" />
-        <div className="bg-gray-100">{children}</div>
-        <div className="w-full mx-auto h-16 relative bg-darkPurple">
-          <div className="footer-top-right-down-slope absolute w-full -top-1 h-10 bg-gray-200" />
-        </div>
+        <div className="flex-1">{children}</div>
+        <footer className="border-t border-blog-border bg-white py-6">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 text-xs text-blog-muted text-center">
+            © {new Date().getFullYear()} Sentry. All rights reserved.
+          </div>
+        </footer>
       </div>
     </Fragment>
   );

--- a/src/app/changelog/layout.tsx
+++ b/src/app/changelog/layout.tsx
@@ -30,12 +30,12 @@ export default async function ChangelogLayout({
 
   return (
     <Fragment>
-      <NextTopLoader color="#6A5FC1" showSpinner={false} />
-      <div className="font-sans bg-white min-h-screen flex flex-col">
+      <NextTopLoader color="#fd44b0" showSpinner={false} />
+      <div className="font-sans bg-darkPurple min-h-screen flex flex-col">
         <GlobalHeader menuItems={menuItems} mode="dark" />
         <div className="flex-1">{children}</div>
-        <footer className="border-t border-blog-border bg-white py-6">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 text-xs text-blog-muted text-center">
+        <footer className="border-t border-white/10 bg-darkPurple py-6">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 text-xs text-white/40 text-center">
             © {new Date().getFullYear()} Sentry. All rights reserved.
           </div>
         </footer>

--- a/src/app/changelog/loading.tsx
+++ b/src/app/changelog/loading.tsx
@@ -7,36 +7,38 @@ export default function Loading() {
   return (
     <Fragment>
       <Header loading />
-      <div className="w-full mx-auto grid grid-cols-12 bg-gray-200">
-        <div className="hidden md:block md:col-span-2 pl-5 pt-10">
-          <h3 className="text-2xl text-primary font-semibold mb-2">
-            Categories:
-          </h3>
-          <div className="flex flex-wrap gap-1 py-1">
-            <div className="bg-gray-300 animate-pulse block rounded w-40 h-8" />
-            <div className="flex flex-wrap gap-1 py-1 mt-2">
-              <div className="bg-gray-300 animate-pulse block rounded w-12 h-6" />
-              <div className="bg-gray-300 animate-pulse block rounded w-20 h-6" />
-              <div className="bg-gray-300 animate-pulse block rounded w-12 h-6" />
-              <div className="bg-gray-300 animate-pulse block rounded w-20 h-6" />
-              <div className="bg-gray-300 animate-pulse block rounded w-16 h-6" />
-              <div className="bg-gray-300 animate-pulse block rounded w-12 h-6" />
-            </div>
+      <main className="w-full bg-surface min-h-screen">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6">
+          {/* Filter bar skeleton */}
+          <div className="py-5 flex items-center gap-2 border-b border-blog-border">
+            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-10" />
+            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-20" />
+            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-16" />
+            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-24" />
+            <div className="ml-auto h-7 bg-gray-100 animate-pulse rounded-full w-36" />
           </div>
-        </div>
-        <div className="col-span-12 md:col-span-8">
-          <div className="max-w-3xl mx-auto px-4 pb-4 sm:px-6 md:px-8 mt-28">
+
+          {/* Jump-to skeleton */}
+          <div className="py-3 flex items-center gap-4 border-b border-blog-border">
+            <div className="h-3 bg-gray-100 animate-pulse rounded w-14" />
+            <div className="h-3 bg-gray-100 animate-pulse rounded w-20" />
+            <div className="h-3 bg-gray-100 animate-pulse rounded w-20" />
+            <div className="h-3 bg-gray-100 animate-pulse rounded w-20" />
+          </div>
+
+          {/* Feed skeleton */}
+          <div className="pt-6 pb-10 space-y-5">
+            {/* Month divider skeleton */}
+            <div className="flex items-center gap-3 mt-2 mb-4">
+              <div className="h-3 bg-gray-100 animate-pulse rounded w-24" />
+              <div className="flex-1 h-px bg-gray-100" />
+            </div>
+            <LoadingArticle />
+            <LoadingArticle />
             <LoadingArticle />
           </div>
         </div>
-        <div className="hidden md:block md:col-span-2 pl-5 pt-10">
-          <h3 className="text-1xl text-primary font-semibold mb-2">Jump to:</h3>
-          <div className="bg-gray-300 animate-pulse block rounded w-40 h-6" />
-          <div className="bg-gray-300 animate-pulse block rounded w-32 h-6 mt-2" />
-          <div className="bg-gray-300 animate-pulse block rounded w-32 h-6 mt-2" />
-          <div className="bg-gray-300 animate-pulse block rounded w-32 h-6 mt-2" />
-        </div>
-      </div>
+      </main>
     </Fragment>
   );
 }

--- a/src/app/changelog/loading.tsx
+++ b/src/app/changelog/loading.tsx
@@ -7,31 +7,31 @@ export default function Loading() {
   return (
     <Fragment>
       <Header loading />
-      <main className="w-full bg-surface min-h-screen">
+      <main className="w-full bg-darkPurple min-h-screen">
         <div className="max-w-4xl mx-auto px-4 sm:px-6">
-          {/* Filter bar skeleton */}
-          <div className="py-5 flex items-center gap-2 border-b border-blog-border">
-            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-10" />
-            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-20" />
-            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-16" />
-            <div className="h-7 bg-gray-100 animate-pulse rounded-full w-24" />
-            <div className="ml-auto h-7 bg-gray-100 animate-pulse rounded-full w-36" />
+          {/* Category nav skeleton */}
+          <div className="py-4 flex items-center gap-2 border-b border-white/10">
+            <div className="h-8 bg-white/10 animate-pulse rounded-lg w-10" />
+            <div className="h-8 bg-white/10 animate-pulse rounded-lg w-20" />
+            <div className="h-8 bg-white/10 animate-pulse rounded-lg w-16" />
+            <div className="h-8 bg-white/10 animate-pulse rounded-lg w-24" />
+            <div className="ml-auto h-8 bg-white/10 animate-pulse rounded-lg w-36" />
           </div>
 
           {/* Jump-to skeleton */}
-          <div className="py-3 flex items-center gap-4 border-b border-blog-border">
-            <div className="h-3 bg-gray-100 animate-pulse rounded w-14" />
-            <div className="h-3 bg-gray-100 animate-pulse rounded w-20" />
-            <div className="h-3 bg-gray-100 animate-pulse rounded w-20" />
-            <div className="h-3 bg-gray-100 animate-pulse rounded w-20" />
+          <div className="py-3 flex items-center gap-4 border-b border-white/10">
+            <div className="h-3 bg-white/10 animate-pulse rounded w-14" />
+            <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
+            <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
+            <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
           </div>
 
           {/* Feed skeleton */}
           <div className="pt-6 pb-10 space-y-5">
             {/* Month divider skeleton */}
             <div className="flex items-center gap-3 mt-2 mb-4">
-              <div className="h-3 bg-gray-100 animate-pulse rounded w-24" />
-              <div className="flex-1 h-px bg-gray-100" />
+              <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
+              <div className="flex-1 h-px bg-white/10" />
             </div>
             <LoadingArticle />
             <LoadingArticle />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,7 @@
   cursor: pointer;
 }
 
+/* Slope utilities kept for backward compat but no longer used in changelog */
 .hero-top-left-down-slope {
   clip-path: polygon(0 0, 100% 0, 100% 100%, 0 40%);
 }
@@ -118,6 +119,61 @@
 
 .footer-top-right-down-slope {
   clip-path: polygon(0 0, 100% 0, 100% 40%, 0 100%);
+}
+
+/* Blog-style article prose overrides */
+.blog-prose {
+  --tw-prose-body: #1D1127;
+  --tw-prose-headings: #1D1127;
+  --tw-prose-links: #6A5FC1;
+  --tw-prose-code: #1D1127;
+  --tw-prose-pre-bg: #1D1127;
+  --tw-prose-counters: #6B6580;
+  --tw-prose-bullets: #6B6580;
+  --tw-prose-hr: #E8E5F0;
+  --tw-prose-quotes: #362d59;
+  --tw-prose-quote-borders: #6A5FC1;
+}
+
+.blog-prose h2 {
+  padding-left: 0.75rem;
+  border-left: 3px solid #6A5FC1;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.blog-prose h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.blog-prose pre {
+  position: relative;
+}
+
+/* Copy button for code blocks */
+.code-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.7rem;
+  color: #9ca3af;
+  background: transparent;
+  border: 1px solid #374151;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.code-copy-btn:hover {
+  color: #f3f4f6;
+  border-color: #6B7280;
+}
+
+/* TOC active heading highlight */
+.toc-link-active {
+  color: #6A5FC1;
+  font-weight: 500;
 }
 
 html {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -190,7 +190,9 @@
   padding-left: 8px;
   border-left: 2px solid #6a5fc1;
   margin-left: -10px;
-  transition: border-color 0.15s, color 0.15s;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
 }
 
 html {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -186,7 +186,11 @@
 /* TOC active heading highlight */
 .toc-link-active {
   color: #6a5fc1;
-  font-weight: 500;
+  font-weight: 600;
+  padding-left: 8px;
+  border-left: 2px solid #6a5fc1;
+  margin-left: -10px;
+  transition: border-color 0.15s, color 0.15s;
 }
 
 html {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,23 +121,34 @@
   clip-path: polygon(0 0, 100% 0, 100% 40%, 0 100%);
 }
 
+/* Prose overrides for dark background (article excerpts on dark bg) */
+.blog-prose-dark {
+  --tw-prose-body: rgba(255, 255, 255, 0.7);
+  --tw-prose-headings: rgba(255, 255, 255, 0.9);
+  --tw-prose-links: #fd44b0;
+  --tw-prose-code: rgba(255, 255, 255, 0.8);
+  --tw-prose-bullets: rgba(255, 255, 255, 0.4);
+  --tw-prose-counters: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.7);
+}
+
 /* Blog-style article prose overrides */
 .blog-prose {
-  --tw-prose-body: #1D1127;
-  --tw-prose-headings: #1D1127;
-  --tw-prose-links: #6A5FC1;
-  --tw-prose-code: #1D1127;
-  --tw-prose-pre-bg: #1D1127;
-  --tw-prose-counters: #6B6580;
-  --tw-prose-bullets: #6B6580;
-  --tw-prose-hr: #E8E5F0;
+  --tw-prose-body: #1d1127;
+  --tw-prose-headings: #1d1127;
+  --tw-prose-links: #6a5fc1;
+  --tw-prose-code: #1d1127;
+  --tw-prose-pre-bg: #1d1127;
+  --tw-prose-counters: #6b6580;
+  --tw-prose-bullets: #6b6580;
+  --tw-prose-hr: #e8e5f0;
   --tw-prose-quotes: #362d59;
-  --tw-prose-quote-borders: #6A5FC1;
+  --tw-prose-quote-borders: #6a5fc1;
 }
 
 .blog-prose h2 {
   padding-left: 0.75rem;
-  border-left: 3px solid #6A5FC1;
+  border-left: 3px solid #6a5fc1;
   margin-top: 2rem;
   margin-bottom: 1rem;
 }
@@ -163,16 +174,18 @@
   border: 1px solid #374151;
   border-radius: 0.25rem;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 .code-copy-btn:hover {
   color: #f3f4f6;
-  border-color: #6B7280;
+  border-color: #6b7280;
 }
 
 /* TOC active heading highlight */
 .toc-link-active {
-  color: #6A5FC1;
+  color: #6a5fc1;
   font-weight: 500;
 }
 

--- a/src/client/components/article.tsx
+++ b/src/client/components/article.tsx
@@ -60,25 +60,36 @@ export function Article({
   );
 }
 
-export function LoadingArticle() {
+export function LoadingArticle({
+  variant = "dark",
+}: {
+  variant?: "dark" | "light";
+}) {
+  const sk = variant === "light" ? "bg-gray-200" : "bg-white/10";
+  const border =
+    variant === "light" ? "border-gray-200" : "border-white/[0.07]";
+  const bg = variant === "light" ? "bg-white" : "bg-white/[0.03]";
+
   return (
-    <article className="rounded-xl border border-white/[0.07] bg-white/[0.03] mb-5 overflow-hidden">
+    <article
+      className={`rounded-xl border ${border} ${bg} mb-5 overflow-hidden`}
+    >
       <div
-        className="w-full bg-white/10 animate-pulse"
+        className={`w-full ${sk} animate-pulse`}
         style={{ aspectRatio: "2/1" }}
       />
       <div className="p-5">
         <div className="flex gap-2 mb-2">
-          <div className="h-3 bg-white/10 w-16 animate-pulse rounded" />
-          <div className="h-3 bg-white/10 w-12 animate-pulse rounded" />
+          <div className={`h-3 ${sk} w-16 animate-pulse rounded`} />
+          <div className={`h-3 ${sk} w-12 animate-pulse rounded`} />
         </div>
-        <div className="h-5 bg-white/10 w-3/4 animate-pulse rounded mb-2" />
+        <div className={`h-5 ${sk} w-3/4 animate-pulse rounded mb-2`} />
         <div className="space-y-1.5 mb-4">
-          <div className="h-4 bg-white/10 animate-pulse rounded" />
-          <div className="h-4 bg-white/10 animate-pulse rounded w-5/6" />
-          <div className="h-4 bg-white/10 animate-pulse rounded w-4/6" />
+          <div className={`h-4 ${sk} animate-pulse rounded`} />
+          <div className={`h-4 ${sk} animate-pulse rounded w-5/6`} />
+          <div className={`h-4 ${sk} animate-pulse rounded w-4/6`} />
         </div>
-        <div className="h-3 bg-white/10 w-24 animate-pulse rounded" />
+        <div className={`h-3 ${sk} w-24 animate-pulse rounded`} />
       </div>
     </article>
   );

--- a/src/client/components/article.tsx
+++ b/src/client/components/article.tsx
@@ -21,37 +21,38 @@ export function Article({
   children,
 }: ArticleProps) {
   return (
-    <article className="bg-white rounded-xl border border-blog-border mb-5 overflow-hidden transition-shadow duration-200 group-hover:shadow-md">
+    <article className="fancy-border bg-transparent rounded-md mb-5 overflow-hidden">
       {image && (
         // biome-ignore lint/performance/noImgElement: <Image> does not resolve here for some reason
         <img
-          className="w-full aspect-video object-cover"
+          className="w-full object-cover"
+          style={{ aspectRatio: "2/1" }}
           src={image}
           alt={title}
         />
       )}
-      <div className="p-6">
+      <div className="py-5">
         {Array.isArray(tags) && tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {tags.map((tag) => (
               <CategoryTag key={tag} text={tag} />
             ))}
           </div>
         )}
-        <h3 className="text-xl font-semibold text-blog-text mb-2 group-hover:text-blog-accent transition-colors duration-150">
+        <h3 className="text-base font-medium text-white mb-2 leading-snug line-clamp-2 group-hover:text-white/80 transition-colors duration-150">
           {title}
         </h3>
-        <div className="prose prose-sm max-w-none text-blog-muted line-clamp-3 blog-prose">
+        <div className="prose prose-sm max-w-none text-white/70 line-clamp-3 blog-prose-dark">
           {children}
         </div>
         <div className="mt-4 flex items-center justify-between">
           {date && (
-            <span className="text-xs text-blog-muted">
+            <span className="text-xs text-white/50">
               <DateComponent date={date} />
             </span>
           )}
-          <span className="text-xs font-medium text-blog-accent group-hover:underline underline-offset-2 ml-auto">
-            Read more →
+          <span className="text-[14px] font-semibold text-[#fd44b0] uppercase ml-auto">
+            Read On →
           </span>
         </div>
       </div>
@@ -61,20 +62,23 @@ export function Article({
 
 export function LoadingArticle() {
   return (
-    <article className="bg-white rounded-xl border border-blog-border mb-5 overflow-hidden">
-      <div className="w-full aspect-video bg-gray-100 animate-pulse" />
-      <div className="p-6">
-        <div className="flex gap-1.5 mb-3">
-          <div className="h-5 bg-gray-100 w-20 animate-pulse rounded-full" />
-          <div className="h-5 bg-gray-100 w-16 animate-pulse rounded-full" />
+    <article className="bg-transparent rounded-md mb-5 overflow-hidden">
+      <div
+        className="w-full bg-white/10 animate-pulse"
+        style={{ aspectRatio: "2/1" }}
+      />
+      <div className="py-5">
+        <div className="flex gap-2 mb-2">
+          <div className="h-3 bg-white/10 w-16 animate-pulse rounded" />
+          <div className="h-3 bg-white/10 w-12 animate-pulse rounded" />
         </div>
-        <div className="h-6 bg-gray-100 w-3/4 animate-pulse rounded mb-2" />
+        <div className="h-5 bg-white/10 w-3/4 animate-pulse rounded mb-2" />
         <div className="space-y-1.5 mb-4">
-          <div className="h-4 bg-gray-100 animate-pulse rounded" />
-          <div className="h-4 bg-gray-100 animate-pulse rounded w-5/6" />
-          <div className="h-4 bg-gray-100 animate-pulse rounded w-4/6" />
+          <div className="h-4 bg-white/10 animate-pulse rounded" />
+          <div className="h-4 bg-white/10 animate-pulse rounded w-5/6" />
+          <div className="h-4 bg-white/10 animate-pulse rounded w-4/6" />
         </div>
-        <div className="h-3 bg-gray-100 w-24 animate-pulse rounded" />
+        <div className="h-3 bg-white/10 w-24 animate-pulse rounded" />
       </div>
     </article>
   );

--- a/src/client/components/article.tsx
+++ b/src/client/components/article.tsx
@@ -42,16 +42,16 @@ export function Article({
         <h3 className="text-base font-medium text-white mb-2 leading-snug line-clamp-2">
           {title}
         </h3>
-        <div className="prose prose-sm max-w-none text-white/60 line-clamp-3 blog-prose-dark">
+        <div className="prose prose-sm max-w-none text-white/75 line-clamp-3 blog-prose-dark">
           {children}
         </div>
         <div className="mt-4 flex items-center justify-between">
           {date && (
-            <span className="text-xs text-white/35">
+            <span className="text-xs text-white/60">
               <DateComponent date={date} />
             </span>
           )}
-          <span className="text-[13px] font-semibold text-[#fd44b0]/70 group-hover:text-[#fd44b0] uppercase tracking-wide ml-auto transition-colors duration-200">
+          <span className="text-[13px] font-semibold text-[#fd44b0] uppercase tracking-wide ml-auto transition-colors duration-200">
             Read On →
           </span>
         </div>

--- a/src/client/components/article.tsx
+++ b/src/client/components/article.tsx
@@ -21,7 +21,7 @@ export function Article({
   children,
 }: ArticleProps) {
   return (
-    <article className="fancy-border bg-transparent rounded-md mb-5 overflow-hidden">
+    <article className="rounded-xl border border-white/[0.07] bg-white/[0.03] mb-5 overflow-hidden transition-all duration-300 group-hover:bg-white/[0.06] group-hover:border-[#fd44b0]/30 group-hover:shadow-[0_8px_32px_rgba(253,68,176,0.08),0_2px_8px_rgba(0,0,0,0.3)]">
       {image && (
         // biome-ignore lint/performance/noImgElement: <Image> does not resolve here for some reason
         <img
@@ -31,7 +31,7 @@ export function Article({
           alt={title}
         />
       )}
-      <div className="py-5">
+      <div className="p-5">
         {Array.isArray(tags) && tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-2">
             {tags.map((tag) => (
@@ -39,19 +39,19 @@ export function Article({
             ))}
           </div>
         )}
-        <h3 className="text-base font-medium text-white mb-2 leading-snug line-clamp-2 group-hover:text-white/80 transition-colors duration-150">
+        <h3 className="text-base font-medium text-white mb-2 leading-snug line-clamp-2">
           {title}
         </h3>
-        <div className="prose prose-sm max-w-none text-white/70 line-clamp-3 blog-prose-dark">
+        <div className="prose prose-sm max-w-none text-white/60 line-clamp-3 blog-prose-dark">
           {children}
         </div>
         <div className="mt-4 flex items-center justify-between">
           {date && (
-            <span className="text-xs text-white/50">
+            <span className="text-xs text-white/35">
               <DateComponent date={date} />
             </span>
           )}
-          <span className="text-[14px] font-semibold text-[#fd44b0] uppercase ml-auto">
+          <span className="text-[13px] font-semibold text-[#fd44b0]/70 group-hover:text-[#fd44b0] uppercase tracking-wide ml-auto transition-colors duration-200">
             Read On →
           </span>
         </div>
@@ -62,12 +62,12 @@ export function Article({
 
 export function LoadingArticle() {
   return (
-    <article className="bg-transparent rounded-md mb-5 overflow-hidden">
+    <article className="rounded-xl border border-white/[0.07] bg-white/[0.03] mb-5 overflow-hidden">
       <div
         className="w-full bg-white/10 animate-pulse"
         style={{ aspectRatio: "2/1" }}
       />
-      <div className="py-5">
+      <div className="p-5">
         <div className="flex gap-2 mb-2">
           <div className="h-3 bg-white/10 w-16 animate-pulse rounded" />
           <div className="h-3 bg-white/10 w-12 animate-pulse rounded" />

--- a/src/client/components/article.tsx
+++ b/src/client/components/article.tsx
@@ -19,31 +19,40 @@ export function Article({
   tags = [],
   date = null,
   children,
-  className,
 }: ArticleProps) {
   return (
-    <article className={`bg-white rounded-lg shadow-lg mb-8 ${className}`}>
+    <article className="bg-white rounded-xl border border-blog-border mb-5 overflow-hidden transition-shadow duration-200 group-hover:shadow-md">
       {image && (
         // biome-ignore lint/performance/noImgElement: <Image> does not resolve here for some reason
         <img
-          className="object-cover rounded-lg rounded-b-none relative w-full h-64"
+          className="w-full aspect-video object-cover"
           src={image}
           alt={title}
         />
       )}
       <div className="p-6">
-        <h3 className="text-3xl text-primary font-semibold mb-2">{title}</h3>
-        <div>
-          <div className="flex flex-wrap gap-1 py-1">
-            {Array.isArray(tags) &&
-              tags.map((tag) => <CategoryTag key={tag} text={tag} />)}
+        {Array.isArray(tags) && tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-3">
+            {tags.map((tag) => (
+              <CategoryTag key={tag} text={tag} />
+            ))}
           </div>
-          <div className="prose max-w-none text-gray-700 py-2">{children}</div>
-          <dl>
-            <dd className="text-xs leading-6 text-gray-400">
-              {date && <DateComponent date={date} />}
-            </dd>
-          </dl>
+        )}
+        <h3 className="text-xl font-semibold text-blog-text mb-2 group-hover:text-blog-accent transition-colors duration-150">
+          {title}
+        </h3>
+        <div className="prose prose-sm max-w-none text-blog-muted line-clamp-3 blog-prose">
+          {children}
+        </div>
+        <div className="mt-4 flex items-center justify-between">
+          {date && (
+            <span className="text-xs text-blog-muted">
+              <DateComponent date={date} />
+            </span>
+          )}
+          <span className="text-xs font-medium text-blog-accent group-hover:underline underline-offset-2 ml-auto">
+            Read more →
+          </span>
         </div>
       </div>
     </article>
@@ -52,20 +61,20 @@ export function Article({
 
 export function LoadingArticle() {
   return (
-    <article className="bg-white rounded-lg shadow-lg mb-8">
+    <article className="bg-white rounded-xl border border-blog-border mb-5 overflow-hidden">
+      <div className="w-full aspect-video bg-gray-100 animate-pulse" />
       <div className="p-6">
-        <div className="h-6 bg-gray-200 mb-2 animate-pulse rounded" />
-        <div className="flex flex-wrap gap-1 py-1">
-          <div className="h-4 bg-gray-200 w-20 animate-pulse rounded" />
+        <div className="flex gap-1.5 mb-3">
+          <div className="h-5 bg-gray-100 w-20 animate-pulse rounded-full" />
+          <div className="h-5 bg-gray-100 w-16 animate-pulse rounded-full" />
         </div>
-        <div className="prose max-w-none text-gray-700 py-2">
-          <div className="h-4 bg-gray-200 mb-2" />
-          <div className="h-4 bg-gray-200 mb-2 animate-pulse rounded" />
-          <div className="h-4 bg-gray-200" />
+        <div className="h-6 bg-gray-100 w-3/4 animate-pulse rounded mb-2" />
+        <div className="space-y-1.5 mb-4">
+          <div className="h-4 bg-gray-100 animate-pulse rounded" />
+          <div className="h-4 bg-gray-100 animate-pulse rounded w-5/6" />
+          <div className="h-4 bg-gray-100 animate-pulse rounded w-4/6" />
         </div>
-        <div className="text-xs leading-6 text-gray-400 animate-pulse rounded">
-          <div className="h-4 bg-gray-200 w-16 animate-pulse rounded" />
-        </div>
+        <div className="h-3 bg-gray-100 w-24 animate-pulse rounded" />
       </div>
     </article>
   );

--- a/src/client/components/copyChangelogButton.tsx
+++ b/src/client/components/copyChangelogButton.tsx
@@ -27,7 +27,7 @@ export function CopyChangelogButton() {
   }
 
   return (
-    <div className="relative">
+    <div className="relative z-50">
       <div className="flex items-center rounded-lg border border-white/20 overflow-hidden text-sm text-white/70">
         <button
           type="button"

--- a/src/client/components/copyChangelogButton.tsx
+++ b/src/client/components/copyChangelogButton.tsx
@@ -16,11 +16,14 @@ export function CopyChangelogButton() {
     setLoading(true);
     try {
       const res = await fetch(markdownUrl);
+      if (!res.ok) return;
       const text = await res.text();
       await navigator.clipboard.writeText(text);
       setCopied(true);
       setOpen(false);
       setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard or fetch error — fail silently
     } finally {
       setLoading(false);
     }

--- a/src/client/components/copyChangelogButton.tsx
+++ b/src/client/components/copyChangelogButton.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyChangelogButton() {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const markdownUrl = "/api/changelog/markdown";
+  const aiPrompt = encodeURIComponent(
+    "Ask questions about Sentry's changelog: https://sentry.io/changelog/",
+  );
+
+  async function handleCopy() {
+    setLoading(true);
+    try {
+      const res = await fetch(markdownUrl);
+      const text = await res.text();
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setOpen(false);
+      setTimeout(() => setCopied(false), 2000);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <div className="flex items-center rounded-lg border border-white/20 overflow-hidden text-sm text-white/70">
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 hover:bg-white/10 transition-colors duration-150 disabled:opacity-50"
+        >
+          {copied ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-3.5 h-3.5 text-green-400"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-3.5 h-3.5"
+              aria-hidden="true"
+            >
+              <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+              <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+            </svg>
+          )}
+          <span>{copied ? "Copied!" : loading ? "Copying…" : "Copy page"}</span>
+        </button>
+
+        <div className="w-px self-stretch bg-white/20" />
+
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-label="More options"
+          aria-expanded={open}
+          className="px-2 py-1.5 hover:bg-white/10 transition-colors duration-150"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-3.5 h-3.5"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute right-0 top-full mt-1.5 w-64 z-20 bg-white border border-blog-border rounded-xl shadow-lg py-1 overflow-hidden">
+            <button
+              type="button"
+              onClick={handleCopy}
+              disabled={loading}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150 text-left disabled:opacity-50"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+                <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text">
+                  Copy page
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Copy page as Markdown for LLMs
+                </div>
+              </div>
+            </button>
+
+            <a
+              href={markdownUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
+                  clipRule="evenodd"
+                />
+                <path
+                  fillRule="evenodd"
+                  d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text">
+                  View as Markdown
+                </div>
+                <div className="text-xs text-blog-muted">
+                  View this page as plain text
+                </div>
+              </div>
+            </a>
+
+            <div className="my-1 border-t border-blog-border" />
+
+            <a
+              href={`https://chatgpt.com/?q=${aiPrompt}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
+                  Open in ChatGPT
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    className="w-3 h-3 text-blog-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Ask ChatGPT questions about this page
+                </div>
+              </div>
+            </a>
+
+            <a
+              href={`https://claude.ai/new?q=${aiPrompt}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-1.778-.097-.614-.028C.88 12.6.272 12.003 0 11.498c0-.317.068-.61.054-.977l.714-.287 1.11.155 1.944.347 2.378.575 1.944.468 1.067.28-.895-.949-1.614-1.677-1.572-1.664-1.261-1.35-.431-.528C2.851 6.606 2.636 5.77 2.8 5.033c.137-.635.48-1.118 1.034-1.44.218-.076.43-.113.64-.113.427 0 .85.158 1.24.46l.018.01.44.42 1.106 1.166 1.836 1.942 1.344 1.44.874.939-.026-.616-.12-1.564-.173-2.496-.087-1.634-.063-1.159.016-.507C11.002 2.637 11.43 2 12.186 2c.574 0 1.163.398 1.38.967l.076.337-.03.856-.25 2.853-.26 2.13-.19 1.49.018.031.26-.468.942-1.644 1.175-2.004 1.167-1.942.677-1.121.185-.28c.336-.408.72-.644 1.155-.703.08-.01.162-.014.24-.014.387 0 .764.126 1.066.38.433.356.72.901.69 1.48-.022.432-.198.86-.52 1.272l-.098.13-.783 1.15-1.806 2.515-.773 1.124-.365.53.561-.17 2.069-.618 1.943-.538 1.69-.424.801-.176.564-.11c.633-.047 1.157.15 1.523.511.295.29.461.68.461 1.088 0 .36-.12.726-.4 1.01-.43.435-1.016.61-1.66.61h-.026l-.84-.06-2.017-.29-2.44-.5-.738-.155.476.386 1.237 1.015 1.82 1.512 1.052.893.766.688.34.356c.347.42.507.878.468 1.337-.045.532-.348 1.01-.795 1.282a1.748 1.748 0 01-.88.254c-.463 0-.932-.18-1.32-.53l-.602-.58-1.328-1.4-1.455-1.616-1.28-1.436-.523-.59-.038.054.04.852.104 2.19.068 1.958.024 1.646-.045.695c-.103.635-.397 1.13-.855 1.393a1.748 1.748 0 01-.88.236c-.418 0-.843-.136-1.175-.405-.42-.34-.67-.862-.67-1.425 0-.116.013-.237.038-.36l.13-.695.442-1.89.746-2.772.526-1.83.15-.52-.472.322-1.776 1.257-1.64 1.128-1.404.927-.655.407-.397.22c-.4.178-.786.267-1.151.267-.661 0-1.218-.296-1.57-.842-.285-.44-.37-.985-.229-1.534.105-.403.335-.78.64-1.071l.43-.365 1.248-.855z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
+                  Open in Claude
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    className="w-3 h-3 text-blog-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Ask Claude questions about this page
+                </div>
+              </div>
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/copyChangelogButton.tsx
+++ b/src/client/components/copyChangelogButton.tsx
@@ -30,7 +30,7 @@ export function CopyChangelogButton() {
   }
 
   return (
-    <div className="relative z-50">
+    <div className="relative z-40">
       <div className="flex items-center rounded-lg border border-white/20 overflow-hidden text-sm text-white/70">
         <button
           type="button"

--- a/src/client/components/copyChangelogButton.tsx
+++ b/src/client/components/copyChangelogButton.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { CopyDropdown } from "./copyDropdown";
 
 export function CopyChangelogButton() {
-  const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -20,7 +20,6 @@ export function CopyChangelogButton() {
       const text = await res.text();
       await navigator.clipboard.writeText(text);
       setCopied(true);
-      setOpen(false);
       setTimeout(() => setCopied(false), 2000);
     } catch {
       // clipboard or fetch error — fail silently
@@ -30,219 +29,14 @@ export function CopyChangelogButton() {
   }
 
   return (
-    <div className="relative z-40">
-      <div className="flex items-center rounded-lg border border-white/20 overflow-hidden text-sm text-white/70">
-        <button
-          type="button"
-          onClick={handleCopy}
-          disabled={loading}
-          className="flex items-center gap-1.5 px-3 py-1.5 hover:bg-white/10 transition-colors duration-150 disabled:opacity-50"
-        >
-          {copied ? (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-3.5 h-3.5 text-green-400"
-              aria-hidden="true"
-            >
-              <path
-                fillRule="evenodd"
-                d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
-                clipRule="evenodd"
-              />
-            </svg>
-          ) : (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-3.5 h-3.5"
-              aria-hidden="true"
-            >
-              <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
-              <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
-            </svg>
-          )}
-          <span>{copied ? "Copied!" : loading ? "Copying…" : "Copy page"}</span>
-        </button>
-
-        <div className="w-px self-stretch bg-white/20" />
-
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-label="More options"
-          aria-expanded={open}
-          className="px-2 self-stretch flex items-center hover:bg-white/10 transition-colors duration-150"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="w-3.5 h-3.5"
-            aria-hidden="true"
-          >
-            <path
-              fillRule="evenodd"
-              d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-
-      {open && (
-        <>
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
-          <div className="absolute right-0 top-full mt-1.5 w-64 z-20 bg-white border border-blog-border rounded-xl shadow-lg py-1 overflow-hidden">
-            <button
-              type="button"
-              onClick={handleCopy}
-              disabled={loading}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150 text-left disabled:opacity-50"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
-                <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text">
-                  Copy page
-                </div>
-                <div className="text-xs text-blog-muted">
-                  Copy page as Markdown for LLMs
-                </div>
-              </div>
-            </button>
-
-            <a
-              href={markdownUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(false)}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
-                  clipRule="evenodd"
-                />
-                <path
-                  fillRule="evenodd"
-                  d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text">
-                  View as Markdown
-                </div>
-                <div className="text-xs text-blog-muted">
-                  View this page as plain text
-                </div>
-              </div>
-            </a>
-
-            <div className="my-1 border-t border-blog-border" />
-
-            <a
-              href={`https://chatgpt.com/?q=${aiPrompt}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(false)}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
-                  Open in ChatGPT
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 12 12"
-                    fill="currentColor"
-                    className="w-3 h-3 text-blog-muted"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div className="text-xs text-blog-muted">
-                  Ask ChatGPT questions about this page
-                </div>
-              </div>
-            </a>
-
-            <a
-              href={`https://claude.ai/new?q=${aiPrompt}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(false)}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-1.778-.097-.614-.028C.88 12.6.272 12.003 0 11.498c0-.317.068-.61.054-.977l.714-.287 1.11.155 1.944.347 2.378.575 1.944.468 1.067.28-.895-.949-1.614-1.677-1.572-1.664-1.261-1.35-.431-.528C2.851 6.606 2.636 5.77 2.8 5.033c.137-.635.48-1.118 1.034-1.44.218-.076.43-.113.64-.113.427 0 .85.158 1.24.46l.018.01.44.42 1.106 1.166 1.836 1.942 1.344 1.44.874.939-.026-.616-.12-1.564-.173-2.496-.087-1.634-.063-1.159.016-.507C11.002 2.637 11.43 2 12.186 2c.574 0 1.163.398 1.38.967l.076.337-.03.856-.25 2.853-.26 2.13-.19 1.49.018.031.26-.468.942-1.644 1.175-2.004 1.167-1.942.677-1.121.185-.28c.336-.408.72-.644 1.155-.703.08-.01.162-.014.24-.014.387 0 .764.126 1.066.38.433.356.72.901.69 1.48-.022.432-.198.86-.52 1.272l-.098.13-.783 1.15-1.806 2.515-.773 1.124-.365.53.561-.17 2.069-.618 1.943-.538 1.69-.424.801-.176.564-.11c.633-.047 1.157.15 1.523.511.295.29.461.68.461 1.088 0 .36-.12.726-.4 1.01-.43.435-1.016.61-1.66.61h-.026l-.84-.06-2.017-.29-2.44-.5-.738-.155.476.386 1.237 1.015 1.82 1.512 1.052.893.766.688.34.356c.347.42.507.878.468 1.337-.045.532-.348 1.01-.795 1.282a1.748 1.748 0 01-.88.254c-.463 0-.932-.18-1.32-.53l-.602-.58-1.328-1.4-1.455-1.616-1.28-1.436-.523-.59-.038.054.04.852.104 2.19.068 1.958.024 1.646-.045.695c-.103.635-.397 1.13-.855 1.393a1.748 1.748 0 01-.88.236c-.418 0-.843-.136-1.175-.405-.42-.34-.67-.862-.67-1.425 0-.116.013-.237.038-.36l.13-.695.442-1.89.746-2.772.526-1.83.15-.52-.472.322-1.776 1.257-1.64 1.128-1.404.927-.655.407-.397.22c-.4.178-.786.267-1.151.267-.661 0-1.218-.296-1.57-.842-.285-.44-.37-.985-.229-1.534.105-.403.335-.78.64-1.071l.43-.365 1.248-.855z" />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
-                  Open in Claude
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 12 12"
-                    fill="currentColor"
-                    className="w-3 h-3 text-blog-muted"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div className="text-xs text-blog-muted">
-                  Ask Claude questions about this page
-                </div>
-              </div>
-            </a>
-          </div>
-        </>
-      )}
-    </div>
+    <CopyDropdown
+      onCopy={handleCopy}
+      markdownUrl={markdownUrl}
+      aiPrompt={aiPrompt}
+      copied={copied}
+      loading={loading}
+      theme="dark"
+      wrapperClass="relative z-40"
+    />
   );
 }

--- a/src/client/components/copyChangelogButton.tsx
+++ b/src/client/components/copyChangelogButton.tsx
@@ -71,7 +71,7 @@ export function CopyChangelogButton() {
           onClick={() => setOpen((v) => !v)}
           aria-label="More options"
           aria-expanded={open}
-          className="px-2 py-1.5 hover:bg-white/10 transition-colors duration-150"
+          className="px-2 self-stretch flex items-center hover:bg-white/10 transition-colors duration-150"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/client/components/copyDropdown.tsx
+++ b/src/client/components/copyDropdown.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface CopyDropdownProps {
+  onCopy: () => void | Promise<void>;
+  markdownUrl: string;
+  aiPrompt: string;
+  copied: boolean;
+  loading?: boolean;
+  theme: Theme;
+  wrapperClass: string;
+}
+
+const style: Record<
+  Theme,
+  {
+    border: string;
+    text: string;
+    hover: string;
+    divider: string;
+    checkColor: string;
+  }
+> = {
+  light: {
+    border: "border-blog-border",
+    text: "text-blog-muted",
+    hover: "hover:bg-surface-overlay",
+    divider: "bg-blog-border",
+    checkColor: "text-green-500",
+  },
+  dark: {
+    border: "border-white/20",
+    text: "text-white/70",
+    hover: "hover:bg-white/10",
+    divider: "bg-white/20",
+    checkColor: "text-green-400",
+  },
+};
+
+export function CopyDropdown({
+  onCopy,
+  markdownUrl,
+  aiPrompt,
+  copied,
+  loading,
+  theme,
+  wrapperClass,
+}: CopyDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const s = style[theme];
+
+  function handleCopyClick() {
+    setOpen(false);
+    onCopy();
+  }
+
+  return (
+    <div className={wrapperClass}>
+      {/* Split button */}
+      <div
+        className={`flex items-center rounded-lg border ${s.border} overflow-hidden text-sm ${s.text}`}
+      >
+        <button
+          type="button"
+          onClick={handleCopyClick}
+          disabled={loading}
+          className={`flex items-center gap-1.5 px-3 py-1.5 ${s.hover} transition-colors duration-150 disabled:opacity-50`}
+        >
+          {copied ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className={`w-3.5 h-3.5 ${s.checkColor}`}
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-3.5 h-3.5"
+              aria-hidden="true"
+            >
+              <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+              <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+            </svg>
+          )}
+          <span>{copied ? "Copied!" : loading ? "Copying…" : "Copy page"}</span>
+        </button>
+
+        <div className={`w-px self-stretch ${s.divider}`} />
+
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-label="More options"
+          aria-expanded={open}
+          className={`px-2 self-stretch flex items-center ${s.hover} transition-colors duration-150`}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-3.5 h-3.5"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Dropdown */}
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute right-0 top-full mt-1.5 w-64 z-20 bg-white border border-blog-border rounded-xl shadow-lg py-1 overflow-hidden">
+            <button
+              type="button"
+              onClick={handleCopyClick}
+              disabled={loading}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150 text-left disabled:opacity-50"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+                <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text">
+                  Copy page
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Copy page as Markdown for LLMs
+                </div>
+              </div>
+            </button>
+
+            <a
+              href={markdownUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
+                  clipRule="evenodd"
+                />
+                <path
+                  fillRule="evenodd"
+                  d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text">
+                  View as Markdown
+                </div>
+                <div className="text-xs text-blog-muted">
+                  View this page as plain text
+                </div>
+              </div>
+            </a>
+
+            <div className="my-1 border-t border-blog-border" />
+
+            <a
+              href={`https://chatgpt.com/?q=${aiPrompt}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
+                  Open in ChatGPT
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    className="w-3 h-3 text-blog-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Ask ChatGPT questions about this page
+                </div>
+              </div>
+            </a>
+
+            <a
+              href={`https://claude.ai/new?q=${aiPrompt}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-1.778-.097-.614-.028C.88 12.6.272 12.003 0 11.498c0-.317.068-.61.054-.977l.714-.287 1.11.155 1.944.347 2.378.575 1.944.468 1.067.28-.895-.949-1.614-1.677-1.572-1.664-1.261-1.35-.431-.528C2.851 6.606 2.636 5.77 2.8 5.033c.137-.635.48-1.118 1.034-1.44.218-.076.43-.113.64-.113.427 0 .85.158 1.24.46l.018.01.44.42 1.106 1.166 1.836 1.942 1.344 1.44.874.939-.026-.616-.12-1.564-.173-2.496-.087-1.634-.063-1.159.016-.507C11.002 2.637 11.43 2 12.186 2c.574 0 1.163.398 1.38.967l.076.337-.03.856-.25 2.853-.26 2.13-.19 1.49.018.031.26-.468.942-1.644 1.175-2.004 1.167-1.942.677-1.121.185-.28c.336-.408.72-.644 1.155-.703.08-.01.162-.014.24-.014.387 0 .764.126 1.066.38.433.356.72.901.69 1.48-.022.432-.198.86-.52 1.272l-.098.13-.783 1.15-1.806 2.515-.773 1.124-.365.53.561-.17 2.069-.618 1.943-.538 1.69-.424.801-.176.564-.11c.633-.047 1.157.15 1.523.511.295.29.461.68.461 1.088 0 .36-.12.726-.4 1.01-.43.435-1.016.61-1.66.61h-.026l-.84-.06-2.017-.29-2.44-.5-.738-.155.476.386 1.237 1.015 1.82 1.512 1.052.893.766.688.34.356c.347.42.507.878.468 1.337-.045.532-.348 1.01-.795 1.282a1.748 1.748 0 01-.88.254c-.463 0-.932-.18-1.32-.53l-.602-.58-1.328-1.4-1.455-1.616-1.28-1.436-.523-.59-.038.054.04.852.104 2.19.068 1.958.024 1.646-.045.695c-.103.635-.397 1.13-.855 1.393a1.748 1.748 0 01-.88.236c-.418 0-.843-.136-1.175-.405-.42-.34-.67-.862-.67-1.425 0-.116.013-.237.038-.36l.13-.695.442-1.89.746-2.772.526-1.83.15-.52-.472.322-1.776 1.257-1.64 1.128-1.404.927-.655.407-.397.22c-.4.178-.786.267-1.151.267-.661 0-1.218-.296-1.57-.842-.285-.44-.37-.985-.229-1.534.105-.403.335-.78.64-1.071l.43-.365 1.248-.855z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
+                  Open in Claude
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    className="w-3 h-3 text-blog-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Ask Claude questions about this page
+                </div>
+              </div>
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/copyPageButton.tsx
+++ b/src/client/components/copyPageButton.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface CopyPageButtonProps {
+  title: string;
+  slug: string;
+  content: string;
+}
+
+export function CopyPageButton({ title, slug, content }: CopyPageButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const pageUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/changelog/${slug}`
+      : `https://sentry.io/changelog/${slug}`;
+
+  const markdownUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/api/changelog/${slug}/markdown`
+      : `https://sentry.io/api/changelog/${slug}/markdown`;
+
+  const aiPrompt = encodeURIComponent(
+    `Ask questions about this Sentry changelog entry: ${pageUrl}`,
+  );
+
+  function handleCopyMarkdown() {
+    const header = `# ${title}\n\nSource: ${pageUrl}\n\n`;
+    navigator.clipboard.writeText(header + content).then(() => {
+      setCopied(true);
+      setOpen(false);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {/* Split button */}
+      <div className="flex items-center rounded-lg border border-blog-border overflow-hidden text-sm text-blog-muted">
+        <button
+          type="button"
+          onClick={handleCopyMarkdown}
+          className="flex items-center gap-1.5 px-3 py-1.5 hover:bg-surface-overlay transition-colors duration-150"
+        >
+          {copied ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-3.5 h-3.5 text-green-500"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-3.5 h-3.5"
+              aria-hidden="true"
+            >
+              <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+              <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+            </svg>
+          )}
+          <span>{copied ? "Copied!" : "Copy page"}</span>
+        </button>
+
+        <div className="w-px self-stretch bg-blog-border" />
+
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-label="More options"
+          aria-expanded={open}
+          className="px-2 py-1.5 hover:bg-surface-overlay transition-colors duration-150"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-3.5 h-3.5"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Dropdown */}
+      {open && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute right-0 top-full mt-1.5 w-64 z-20 bg-white border border-blog-border rounded-xl shadow-lg py-1 overflow-hidden">
+            <button
+              type="button"
+              onClick={handleCopyMarkdown}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150 text-left"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+                <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text">
+                  Copy page
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Copy page as Markdown for LLMs
+                </div>
+              </div>
+            </button>
+
+            <a
+              href={markdownUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
+                  clipRule="evenodd"
+                />
+                <path
+                  fillRule="evenodd"
+                  d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text">
+                  View as Markdown
+                </div>
+                <div className="text-xs text-blog-muted">
+                  View this page as plain text
+                </div>
+              </div>
+            </a>
+
+            <div className="my-1 border-t border-blog-border" />
+
+            <a
+              href={`https://chatgpt.com/?q=${aiPrompt}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              {/* ChatGPT icon */}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
+                  Open in ChatGPT
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    className="w-3 h-3 text-blog-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Ask ChatGPT questions about this page
+                </div>
+              </div>
+            </a>
+
+            <a
+              href={`https://claude.ai/new?q=${aiPrompt}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
+            >
+              {/* Claude icon */}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-1.778-.097-.614-.028C.88 12.6.272 12.003 0 11.498c0-.317.068-.61.054-.977l.714-.287 1.11.155 1.944.347 2.378.575 1.944.468 1.067.28-.895-.949-1.614-1.677-1.572-1.664-1.261-1.35-.431-.528C2.851 6.606 2.636 5.77 2.8 5.033c.137-.635.48-1.118 1.034-1.44.218-.076.43-.113.64-.113.427 0 .85.158 1.24.46l.018.01.44.42 1.106 1.166 1.836 1.942 1.344 1.44.874.939-.026-.616-.12-1.564-.173-2.496-.087-1.634-.063-1.159.016-.507C11.002 2.637 11.43 2 12.186 2c.574 0 1.163.398 1.38.967l.076.337-.03.856-.25 2.853-.26 2.13-.19 1.49.018.031.26-.468.942-1.644 1.175-2.004 1.167-1.942.677-1.121.185-.28c.336-.408.72-.644 1.155-.703.08-.01.162-.014.24-.014.387 0 .764.126 1.066.38.433.356.72.901.69 1.48-.022.432-.198.86-.52 1.272l-.098.13-.783 1.15-1.806 2.515-.773 1.124-.365.53.561-.17 2.069-.618 1.943-.538 1.69-.424.801-.176.564-.11c.633-.047 1.157.15 1.523.511.295.29.461.68.461 1.088 0 .36-.12.726-.4 1.01-.43.435-1.016.61-1.66.61h-.026l-.84-.06-2.017-.29-2.44-.5-.738-.155.476.386 1.237 1.015 1.82 1.512 1.052.893.766.688.34.356c.347.42.507.878.468 1.337-.045.532-.348 1.01-.795 1.282a1.674 1.674 0 01-.88.254c-.463 0-.932-.18-1.32-.53l-.602-.58-1.328-1.4-1.455-1.616-1.28-1.436-.523-.59-.038.054.04.852.104 2.19.068 1.958.024 1.646-.045.695c-.103.635-.397 1.13-.855 1.393a1.748 1.748 0 01-.88.236c-.418 0-.843-.136-1.175-.405-.42-.34-.67-.862-.67-1.425 0-.116.013-.237.038-.36l.13-.695.442-1.89.746-2.772.526-1.83.15-.52-.472.322-1.776 1.257-1.64 1.128-1.404.927-.655.407-.397.22c-.4.178-.786.267-1.151.267-.661 0-1.218-.296-1.57-.842-.285-.44-.37-.985-.229-1.534.105-.403.335-.78.64-1.071l.43-.365 1.248-.855z" />
+              </svg>
+              <div>
+                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
+                  Open in Claude
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 12 12"
+                    fill="currentColor"
+                    className="w-3 h-3 text-blog-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="text-xs text-blog-muted">
+                  Ask Claude questions about this page
+                </div>
+              </div>
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/copyPageButton.tsx
+++ b/src/client/components/copyPageButton.tsx
@@ -37,7 +37,7 @@ export function CopyPageButton({ title, slug, content }: CopyPageButtonProps) {
   }
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative z-50" ref={containerRef}>
       {/* Split button */}
       <div className="flex items-center rounded-lg border border-blog-border overflow-hidden text-sm text-blog-muted">
         <button

--- a/src/client/components/copyPageButton.tsx
+++ b/src/client/components/copyPageButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { CopyDropdown } from "./copyDropdown";
 
 interface CopyPageButtonProps {
   title: string;
@@ -9,7 +10,6 @@ interface CopyPageButtonProps {
 }
 
 export function CopyPageButton({ title, slug, content }: CopyPageButtonProps) {
-  const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [pageUrl, setPageUrl] = useState(`https://sentry.io/changelog/${slug}`);
 
@@ -22,235 +22,21 @@ export function CopyPageButton({ title, slug, content }: CopyPageButtonProps) {
     `Ask questions about this Sentry changelog entry: ${pageUrl}`,
   );
 
-  function handleCopyMarkdown() {
+  async function handleCopy() {
     const header = `# ${title}\n\nSource: ${pageUrl}\n\n`;
-    navigator.clipboard
-      .writeText(header + content)
-      .then(() => {
-        setCopied(true);
-        setOpen(false);
-        setTimeout(() => setCopied(false), 2000);
-      })
-      .catch(() => {});
+    await navigator.clipboard.writeText(header + content).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   return (
-    <div className="relative z-50">
-      {/* Split button */}
-      <div className="flex items-center rounded-lg border border-blog-border overflow-hidden text-sm text-blog-muted">
-        <button
-          type="button"
-          onClick={handleCopyMarkdown}
-          className="flex items-center gap-1.5 px-3 py-1.5 hover:bg-surface-overlay transition-colors duration-150"
-        >
-          {copied ? (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-3.5 h-3.5 text-green-500"
-              aria-hidden="true"
-            >
-              <path
-                fillRule="evenodd"
-                d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
-                clipRule="evenodd"
-              />
-            </svg>
-          ) : (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-3.5 h-3.5"
-              aria-hidden="true"
-            >
-              <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
-              <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
-            </svg>
-          )}
-          <span>{copied ? "Copied!" : "Copy page"}</span>
-        </button>
-
-        <div className="w-px self-stretch bg-blog-border" />
-
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-label="More options"
-          aria-expanded={open}
-          className="px-2 self-stretch flex items-center hover:bg-surface-overlay transition-colors duration-150"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="w-3.5 h-3.5"
-            aria-hidden="true"
-          >
-            <path
-              fillRule="evenodd"
-              d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-
-      {/* Dropdown */}
-      {open && (
-        <>
-          {/* Backdrop */}
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
-          <div className="absolute right-0 top-full mt-1.5 w-64 z-20 bg-white border border-blog-border rounded-xl shadow-lg py-1 overflow-hidden">
-            <button
-              type="button"
-              onClick={handleCopyMarkdown}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150 text-left"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
-                <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text">
-                  Copy page
-                </div>
-                <div className="text-xs text-blog-muted">
-                  Copy page as Markdown for LLMs
-                </div>
-              </div>
-            </button>
-
-            <a
-              href={markdownUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(false)}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
-                  clipRule="evenodd"
-                />
-                <path
-                  fillRule="evenodd"
-                  d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text">
-                  View as Markdown
-                </div>
-                <div className="text-xs text-blog-muted">
-                  View this page as plain text
-                </div>
-              </div>
-            </a>
-
-            <div className="my-1 border-t border-blog-border" />
-
-            <a
-              href={`https://chatgpt.com/?q=${aiPrompt}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(false)}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
-            >
-              {/* ChatGPT icon */}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
-                  Open in ChatGPT
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 12 12"
-                    fill="currentColor"
-                    className="w-3 h-3 text-blog-muted"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div className="text-xs text-blog-muted">
-                  Ask ChatGPT questions about this page
-                </div>
-              </div>
-            </a>
-
-            <a
-              href={`https://claude.ai/new?q=${aiPrompt}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(false)}
-              className="flex items-start gap-3 w-full px-4 py-2.5 hover:bg-surface-overlay transition-colors duration-150"
-            >
-              {/* Claude icon */}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="w-4 h-4 mt-0.5 text-blog-muted shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-1.778-.097-.614-.028C.88 12.6.272 12.003 0 11.498c0-.317.068-.61.054-.977l.714-.287 1.11.155 1.944.347 2.378.575 1.944.468 1.067.28-.895-.949-1.614-1.677-1.572-1.664-1.261-1.35-.431-.528C2.851 6.606 2.636 5.77 2.8 5.033c.137-.635.48-1.118 1.034-1.44.218-.076.43-.113.64-.113.427 0 .85.158 1.24.46l.018.01.44.42 1.106 1.166 1.836 1.942 1.344 1.44.874.939-.026-.616-.12-1.564-.173-2.496-.087-1.634-.063-1.159.016-.507C11.002 2.637 11.43 2 12.186 2c.574 0 1.163.398 1.38.967l.076.337-.03.856-.25 2.853-.26 2.13-.19 1.49.018.031.26-.468.942-1.644 1.175-2.004 1.167-1.942.677-1.121.185-.28c.336-.408.72-.644 1.155-.703.08-.01.162-.014.24-.014.387 0 .764.126 1.066.38.433.356.72.901.69 1.48-.022.432-.198.86-.52 1.272l-.098.13-.783 1.15-1.806 2.515-.773 1.124-.365.53.561-.17 2.069-.618 1.943-.538 1.69-.424.801-.176.564-.11c.633-.047 1.157.15 1.523.511.295.29.461.68.461 1.088 0 .36-.12.726-.4 1.01-.43.435-1.016.61-1.66.61h-.026l-.84-.06-2.017-.29-2.44-.5-.738-.155.476.386 1.237 1.015 1.82 1.512 1.052.893.766.688.34.356c.347.42.507.878.468 1.337-.045.532-.348 1.01-.795 1.282a1.674 1.674 0 01-.88.254c-.463 0-.932-.18-1.32-.53l-.602-.58-1.328-1.4-1.455-1.616-1.28-1.436-.523-.59-.038.054.04.852.104 2.19.068 1.958.024 1.646-.045.695c-.103.635-.397 1.13-.855 1.393a1.748 1.748 0 01-.88.236c-.418 0-.843-.136-1.175-.405-.42-.34-.67-.862-.67-1.425 0-.116.013-.237.038-.36l.13-.695.442-1.89.746-2.772.526-1.83.15-.52-.472.322-1.776 1.257-1.64 1.128-1.404.927-.655.407-.397.22c-.4.178-.786.267-1.151.267-.661 0-1.218-.296-1.57-.842-.285-.44-.37-.985-.229-1.534.105-.403.335-.78.64-1.071l.43-.365 1.248-.855z" />
-              </svg>
-              <div>
-                <div className="text-sm font-medium text-blog-text flex items-center gap-1">
-                  Open in Claude
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 12 12"
-                    fill="currentColor"
-                    className="w-3 h-3 text-blog-muted"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M3.884 2.25a.75.75 0 000 1.5h2.566L2.22 7.97a.75.75 0 101.06 1.06l4.22-4.22v2.56a.75.75 0 001.5 0V2.25H3.884z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div className="text-xs text-blog-muted">
-                  Ask Claude questions about this page
-                </div>
-              </div>
-            </a>
-          </div>
-        </>
-      )}
-    </div>
+    <CopyDropdown
+      onCopy={handleCopy}
+      markdownUrl={markdownUrl}
+      aiPrompt={aiPrompt}
+      copied={copied}
+      theme="light"
+      wrapperClass="relative z-50"
+    />
   );
 }

--- a/src/client/components/copyPageButton.tsx
+++ b/src/client/components/copyPageButton.tsx
@@ -81,7 +81,7 @@ export function CopyPageButton({ title, slug, content }: CopyPageButtonProps) {
           onClick={() => setOpen((v) => !v)}
           aria-label="More options"
           aria-expanded={open}
-          className="px-2 py-1.5 hover:bg-surface-overlay transition-colors duration-150"
+          className="px-2 self-stretch flex items-center hover:bg-surface-overlay transition-colors duration-150"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/client/components/copyPageButton.tsx
+++ b/src/client/components/copyPageButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface CopyPageButtonProps {
   title: string;
@@ -11,33 +11,31 @@ interface CopyPageButtonProps {
 export function CopyPageButton({ title, slug, content }: CopyPageButtonProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [pageUrl, setPageUrl] = useState(`https://sentry.io/changelog/${slug}`);
 
-  const pageUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}/changelog/${slug}`
-      : `https://sentry.io/changelog/${slug}`;
+  useEffect(() => {
+    setPageUrl(`${window.location.origin}/changelog/${slug}`);
+  }, [slug]);
 
-  const markdownUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}/api/changelog/${slug}/markdown`
-      : `https://sentry.io/api/changelog/${slug}/markdown`;
-
+  const markdownUrl = `/api/changelog/${slug}/markdown`;
   const aiPrompt = encodeURIComponent(
     `Ask questions about this Sentry changelog entry: ${pageUrl}`,
   );
 
   function handleCopyMarkdown() {
     const header = `# ${title}\n\nSource: ${pageUrl}\n\n`;
-    navigator.clipboard.writeText(header + content).then(() => {
-      setCopied(true);
-      setOpen(false);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    navigator.clipboard
+      .writeText(header + content)
+      .then(() => {
+        setCopied(true);
+        setOpen(false);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
   }
 
   return (
-    <div className="relative z-50" ref={containerRef}>
+    <div className="relative z-50">
       {/* Split button */}
       <div className="flex items-center rounded-lg border border-blog-border overflow-hidden text-sm text-blog-muted">
         <button

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -185,81 +185,114 @@ export function ChangelogList({
   return (
     <main className="w-full bg-darkPurple min-h-screen">
       <div className="max-w-5xl mx-auto px-4 sm:px-6">
-        {/* Top nav — search only, no category pills */}
-        <div className="py-4 flex items-center gap-3 border-b border-white/10 sticky top-[4.5rem] z-30 bg-darkPurple">
-          {/* Mobile: jump-to dropdown */}
-          {visibleMonths.length > 0 && (
-            <div className="flex items-center gap-2 sm:hidden flex-1 min-w-0">
-              <select
-                value={monthAndYearParam ?? ""}
-                onChange={(e) => {
-                  setMonthParam(e.target.value || null);
-                  setPageParam(null);
-                }}
-                className="flex-1 text-xs rounded-lg border border-white/25 bg-white/10 text-white px-2 py-1.5 focus:outline-none focus:border-[#fd44b0] appearance-none"
-              >
-                <option value="" className="bg-darkPurple text-white">
-                  All months
-                </option>
-                {visibleMonths.map((monthAndYear) => (
-                  <option
-                    key={monthAndYear}
-                    value={monthAndYear}
-                    className="bg-darkPurple text-white"
-                  >
-                    {monthAndYear}
+        {/* Top nav — search, category pills, mobile month */}
+        <div className="py-4 flex flex-col gap-3 border-b border-white/10 sticky top-[4.5rem] z-30 bg-darkPurple">
+          {/* Row 1: mobile month dropdown + search + reset */}
+          <div className="flex items-center gap-3">
+            {visibleMonths.length > 0 && (
+              <div className="flex items-center gap-2 sm:hidden flex-1 min-w-0">
+                <select
+                  value={monthAndYearParam ?? ""}
+                  onChange={(e) => {
+                    setMonthParam(e.target.value || null);
+                    setPageParam(null);
+                  }}
+                  className="flex-1 text-xs rounded-lg border border-white/25 bg-white/10 text-white px-2 py-1.5 focus:outline-none focus:border-[#fd44b0] appearance-none"
+                >
+                  <option value="" className="bg-darkPurple text-white">
+                    All months
                   </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* Search + Reset */}
-          <div className="flex items-center gap-2 flex-shrink-0 sm:ml-auto">
-            {someFilterIsActive && (
-              <button
-                type="button"
-                className="text-sm text-white/50 hover:text-white transition-colors duration-150"
-                onClick={() => {
-                  setSearchValue(null);
-                  setQuerySearchValue(null);
-                  setSelectedCategoriesIds(null);
-                  setMonthParam(null);
-                  setPageParam(null);
-                }}
-              >
-                Reset
-              </button>
+                  {visibleMonths.map((monthAndYear) => (
+                    <option
+                      key={monthAndYear}
+                      value={monthAndYear}
+                      className="bg-darkPurple text-white"
+                    >
+                      {monthAndYear}
+                    </option>
+                  ))}
+                </select>
+              </div>
             )}
-            <div className="relative">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40 pointer-events-none"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-                  clipRule="evenodd"
+
+            <div className="flex items-center gap-2 flex-shrink-0 sm:ml-auto">
+              {someFilterIsActive && (
+                <button
+                  type="button"
+                  className="text-sm text-white/50 hover:text-white transition-colors duration-150"
+                  onClick={() => {
+                    setSearchValue(null);
+                    setQuerySearchValue(null);
+                    setSelectedCategoriesIds(null);
+                    setMonthParam(null);
+                    setPageParam(null);
+                  }}
+                >
+                  Reset
+                </button>
+              )}
+              <div className="relative">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40 pointer-events-none"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <input
+                  aria-label="Search..."
+                  type="text"
+                  value={searchValue ?? ""}
+                  onChange={(e) => {
+                    setPageParam(null);
+                    const newSearchValue = e.target.value
+                      ? e.target.value
+                      : null;
+                    setSearchValue(newSearchValue);
+                    setQuerySearchValue(newSearchValue);
+                  }}
+                  placeholder="Search..."
+                  className="pl-8 pr-3 py-1.5 text-sm rounded-lg border border-white/25 bg-white/10 text-white placeholder:text-white/40 focus:outline-none focus:border-[#fd44b0] w-36 sm:w-44"
                 />
-              </svg>
-              <input
-                aria-label="Search..."
-                type="text"
-                value={searchValue ?? ""}
-                onChange={(e) => {
-                  setPageParam(null);
-                  const newSearchValue = e.target.value ? e.target.value : null;
-                  setSearchValue(newSearchValue);
-                  setQuerySearchValue(newSearchValue);
-                }}
-                placeholder="Search..."
-                className="pl-8 pr-3 py-1.5 text-sm rounded-lg border border-white/25 bg-white/10 text-white placeholder:text-white/40 focus:outline-none focus:border-[#fd44b0] w-36 sm:w-44"
-              />
+              </div>
             </div>
           </div>
+
+          {/* Row 2: category pills */}
+          {Object.keys(allChangelogCategories).length > 0 && (
+            <div className="flex items-center gap-2 overflow-x-auto">
+              {Object.values(allChangelogCategories)
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((category) => (
+                  <button
+                    key={category.id}
+                    type="button"
+                    onClick={() => {
+                      const next = selectedCategoriesIds.includes(category.id)
+                        ? selectedCategoriesIds.filter(
+                            (id) => id !== category.id,
+                          )
+                        : [...selectedCategoriesIds, category.id];
+                      setSelectedCategoriesIds(next.length === 0 ? null : next);
+                      setPageParam(null);
+                    }}
+                    className={`flex-shrink-0 text-xs px-2.5 py-1 rounded-full border transition-colors duration-150 ${
+                      selectedCategoriesIds.includes(category.id)
+                        ? "bg-[#fd44b0] border-[#fd44b0] text-white"
+                        : "border-white/20 text-white/60 hover:text-white hover:border-white/40"
+                    }`}
+                  >
+                    {category.name}
+                  </button>
+                ))}
+            </div>
+          )}
         </div>
 
         {/* Two-column layout on desktop */}

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -172,58 +172,48 @@ export function ChangelogList({
       );
     });
 
+  const visibleMonths = sortedDatesGroupedByMonthAndYear.filter((monthAndYear) =>
+    filteredChangelogsWithoutMonthFilter.some(
+      (changelog) =>
+        changelogEntryPublishDateToAddressableTag(new Date(changelog.publishedAt)) ===
+        monthAndYear,
+    ),
+  );
+
   return (
     <main className="w-full bg-darkPurple min-h-screen">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6">
-        {/* Category nav — sticky, matches blog-category-nav */}
+      <div className="max-w-5xl mx-auto px-4 sm:px-6">
+        {/* Top nav — search only, no category pills */}
         <div className="py-4 flex items-center gap-3 border-b border-white/10 sticky top-[4.5rem] z-30 bg-darkPurple">
-          {/* Category pills — hidden on mobile */}
-          <div className="hidden sm:flex items-center gap-2 overflow-x-auto flex-1 min-w-0">
-            <button
-              type="button"
-              onClick={() => {
-                setSelectedCategoriesIds(null);
-                setPageParam(null);
-              }}
-              className={`btn-new secondary-dark flex-shrink-0 !h-auto !py-1.5 !px-3 !text-[13px] ${
-                selectedCategoriesIds.length === 0 ? "!bg-[position:2%_0]" : ""
-              }`}
-            >
-              All
-            </button>
-            {Object.values(allChangelogCategories).map((category) => {
-              const isActive = selectedCategoriesIds.includes(category.id);
-              return (
-                <button
-                  key={category.id}
-                  type="button"
-                  onClick={() => {
-                    if (isActive) {
-                      setSelectedCategoriesIds(
-                        selectedCategoriesIds.filter(
-                          (id) => id !== category.id,
-                        ),
-                      );
-                    } else {
-                      setSelectedCategoriesIds([
-                        ...selectedCategoriesIds,
-                        category.id,
-                      ]);
-                    }
-                    setPageParam(null);
-                  }}
-                  className={`btn-new secondary-dark flex-shrink-0 !h-auto !py-1.5 !px-3 !text-[13px] ${
-                    isActive ? "!bg-[position:2%_0]" : ""
-                  }`}
-                >
-                  {category.name}
-                </button>
-              );
-            })}
-          </div>
+          {/* Mobile: jump-to dropdown */}
+          {visibleMonths.length > 0 && (
+            <div className="flex items-center gap-2 sm:hidden flex-1 min-w-0">
+              <select
+                value={monthAndYearParam ?? ""}
+                onChange={(e) => {
+                  setMonthParam(e.target.value || null);
+                  setPageParam(null);
+                }}
+                className="flex-1 text-xs rounded-lg border border-white/25 bg-white/10 text-white px-2 py-1.5 focus:outline-none focus:border-[#fd44b0] appearance-none"
+              >
+                <option value="" className="bg-darkPurple text-white">
+                  All months
+                </option>
+                {visibleMonths.map((monthAndYear) => (
+                  <option
+                    key={monthAndYear}
+                    value={monthAndYear}
+                    className="bg-darkPurple text-white"
+                  >
+                    {monthAndYear}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* Search + Reset */}
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2 flex-shrink-0 sm:ml-auto">
             <div className="relative">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -270,53 +260,44 @@ export function ChangelogList({
           </div>
         </div>
 
-        {/* Jump-to month */}
-        {sortedDatesGroupedByMonthAndYear.length > 0 &&
-          (() => {
-            const visibleMonths = sortedDatesGroupedByMonthAndYear.filter(
-              (monthAndYear) =>
-                filteredChangelogsWithoutMonthFilter.some(
-                  (changelog) =>
-                    changelogEntryPublishDateToAddressableTag(
-                      new Date(changelog.publishedAt),
-                    ) === monthAndYear,
-                ),
-            );
-            return (
-              <div className="py-3 border-b border-white/10">
-                {/* Mobile: select dropdown */}
-                <div className="flex items-center gap-2 sm:hidden">
-                  <span className="text-xs font-semibold uppercase tracking-widest text-white/40 whitespace-nowrap">
-                    Jump to:
-                  </span>
-                  <select
-                    value={monthAndYearParam ?? ""}
-                    onChange={(e) => {
-                      setMonthParam(e.target.value || null);
-                      setPageParam(null);
-                    }}
-                    className="flex-1 text-xs rounded-lg border border-white/25 bg-white/10 text-white px-2 py-1.5 focus:outline-none focus:border-[#fd44b0] appearance-none"
-                  >
-                    <option value="" className="bg-darkPurple text-white">
-                      All months
-                    </option>
-                    {visibleMonths.map((monthAndYear) => (
-                      <option
-                        key={monthAndYear}
-                        value={monthAndYear}
-                        className="bg-darkPurple text-white"
-                      >
-                        {monthAndYear}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+        {/* Two-column layout on desktop */}
+        <div className="sm:flex sm:gap-10">
+          {/* Feed */}
+          <div className="flex-1 min-w-0 pb-10">
+            {paginatedChangelogs}
 
-                {/* Desktop: inline buttons */}
-                <div className="hidden sm:flex flex-wrap gap-x-4 gap-y-1 items-center">
-                  <span className="text-xs font-semibold uppercase tracking-widest text-white/40">
-                    Jump to:
-                  </span>
+            {paginatedChangelogs.length === 0 && (
+              <div className="flex items-center gap-3 my-10">
+                <div className="flex-1 h-px bg-white/10" />
+                <span className="text-sm text-white/40">No posts found.</span>
+                <div className="flex-1 h-px bg-white/10" />
+              </div>
+            )}
+
+            {numberOfPages > 1 && (
+              <div className="mt-8">
+                <Pagination
+                  currentPage={selectedPage}
+                  totalPages={numberOfPages}
+                  onPageNumberChange={(pageNumber) => {
+                    setPageParam(pageNumber, { history: "push" });
+                  }}
+                  search={searchValue}
+                  selectedMonth={monthAndYearParam}
+                  selectedCategoriesIds={selectedCategoriesIds}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Right sidebar — date navigator, desktop only */}
+          {visibleMonths.length > 0 && (
+            <div className="hidden sm:block w-40 flex-shrink-0">
+              <div className="sticky top-[7rem] pt-6">
+                <span className="text-[10px] font-semibold uppercase tracking-widest text-white/35">
+                  Jump to
+                </span>
+                <div className="mt-3 flex flex-col gap-2">
                   {visibleMonths.map((monthAndYear) => (
                     <button
                       key={monthAndYear}
@@ -329,10 +310,10 @@ export function ChangelogList({
                         }
                         setPageParam(null);
                       }}
-                      className={`text-xs transition-colors duration-150 ${
+                      className={`text-left text-xs transition-colors duration-150 ${
                         monthAndYearParam === monthAndYear
-                          ? "text-[#fd44b0] font-semibold underline underline-offset-2"
-                          : "text-white/50 hover:text-white"
+                          ? "text-[#fd44b0] font-semibold"
+                          : "text-white/40 hover:text-white/80"
                       }`}
                     >
                       {monthAndYear}
@@ -340,33 +321,6 @@ export function ChangelogList({
                   ))}
                 </div>
               </div>
-            );
-          })()}
-
-        {/* Feed */}
-        <div className="pb-10">
-          {paginatedChangelogs}
-
-          {paginatedChangelogs.length === 0 && (
-            <div className="flex items-center gap-3 my-10">
-              <div className="flex-1 h-px bg-white/10" />
-              <span className="text-sm text-white/40">No posts found.</span>
-              <div className="flex-1 h-px bg-white/10" />
-            </div>
-          )}
-
-          {numberOfPages > 1 && (
-            <div className="mt-8">
-              <Pagination
-                currentPage={selectedPage}
-                totalPages={numberOfPages}
-                onPageNumberChange={(pageNumber) => {
-                  setPageParam(pageNumber, { history: "push" });
-                }}
-                search={searchValue}
-                selectedMonth={monthAndYearParam}
-                selectedCategoriesIds={selectedCategoriesIds}
-              />
             </div>
           )}
         </div>

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -216,6 +216,21 @@ export function ChangelogList({
 
           {/* Search + Reset */}
           <div className="flex items-center gap-2 flex-shrink-0 sm:ml-auto">
+            {someFilterIsActive && (
+              <button
+                type="button"
+                className="text-sm text-white/50 hover:text-white transition-colors duration-150"
+                onClick={() => {
+                  setSearchValue(null);
+                  setQuerySearchValue(null);
+                  setSelectedCategoriesIds(null);
+                  setMonthParam(null);
+                  setPageParam(null);
+                }}
+              >
+                Reset
+              </button>
+            )}
             <div className="relative">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -244,21 +259,6 @@ export function ChangelogList({
                 className="pl-8 pr-3 py-1.5 text-sm rounded-lg border border-white/25 bg-white/10 text-white placeholder:text-white/40 focus:outline-none focus:border-[#fd44b0] w-36 sm:w-44"
               />
             </div>
-            {someFilterIsActive && (
-              <button
-                type="button"
-                className="text-sm text-white/50 hover:text-white transition-colors duration-150"
-                onClick={() => {
-                  setSearchValue(null);
-                  setQuerySearchValue(null);
-                  setSelectedCategoriesIds(null);
-                  setMonthParam(null);
-                  setPageParam(null);
-                }}
-              >
-                Reset
-              </button>
-            )}
           </div>
         </div>
 

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -271,43 +271,77 @@ export function ChangelogList({
         </div>
 
         {/* Jump-to month */}
-        {sortedDatesGroupedByMonthAndYear.length > 0 && (
-          <div className="py-3 flex flex-wrap gap-x-4 gap-y-1 border-b border-white/10">
-            <span className="text-xs font-semibold uppercase tracking-widest text-white/40 self-center">
-              Jump to:
-            </span>
-            {sortedDatesGroupedByMonthAndYear
-              .filter((monthAndYear) =>
+        {sortedDatesGroupedByMonthAndYear.length > 0 &&
+          (() => {
+            const visibleMonths = sortedDatesGroupedByMonthAndYear.filter(
+              (monthAndYear) =>
                 filteredChangelogsWithoutMonthFilter.some(
                   (changelog) =>
                     changelogEntryPublishDateToAddressableTag(
                       new Date(changelog.publishedAt),
                     ) === monthAndYear,
                 ),
-              )
-              .map((monthAndYear) => (
-                <button
-                  key={monthAndYear}
-                  type="button"
-                  onClick={() => {
-                    if (monthAndYearParam === monthAndYear) {
-                      setMonthParam(null);
-                    } else {
-                      setMonthParam(monthAndYear);
-                    }
-                    setPageParam(null);
-                  }}
-                  className={`text-xs transition-colors duration-150 ${
-                    monthAndYearParam === monthAndYear
-                      ? "text-[#fd44b0] font-semibold underline underline-offset-2"
-                      : "text-white/50 hover:text-white"
-                  }`}
-                >
-                  {monthAndYear}
-                </button>
-              ))}
-          </div>
-        )}
+            );
+            return (
+              <div className="py-3 border-b border-white/10">
+                {/* Mobile: select dropdown */}
+                <div className="flex items-center gap-2 sm:hidden">
+                  <span className="text-xs font-semibold uppercase tracking-widest text-white/40 whitespace-nowrap">
+                    Jump to:
+                  </span>
+                  <select
+                    value={monthAndYearParam ?? ""}
+                    onChange={(e) => {
+                      setMonthParam(e.target.value || null);
+                      setPageParam(null);
+                    }}
+                    className="flex-1 text-xs rounded-lg border border-white/25 bg-white/10 text-white px-2 py-1.5 focus:outline-none focus:border-[#fd44b0] appearance-none"
+                  >
+                    <option value="" className="bg-darkPurple text-white">
+                      All months
+                    </option>
+                    {visibleMonths.map((monthAndYear) => (
+                      <option
+                        key={monthAndYear}
+                        value={monthAndYear}
+                        className="bg-darkPurple text-white"
+                      >
+                        {monthAndYear}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Desktop: inline buttons */}
+                <div className="hidden sm:flex flex-wrap gap-x-4 gap-y-1 items-center">
+                  <span className="text-xs font-semibold uppercase tracking-widest text-white/40">
+                    Jump to:
+                  </span>
+                  {visibleMonths.map((monthAndYear) => (
+                    <button
+                      key={monthAndYear}
+                      type="button"
+                      onClick={() => {
+                        if (monthAndYearParam === monthAndYear) {
+                          setMonthParam(null);
+                        } else {
+                          setMonthParam(monthAndYear);
+                        }
+                        setPageParam(null);
+                      }}
+                      className={`text-xs transition-colors duration-150 ${
+                        monthAndYearParam === monthAndYear
+                          ? "text-[#fd44b0] font-semibold underline underline-offset-2"
+                          : "text-white/50 hover:text-white"
+                      }`}
+                    >
+                      {monthAndYear}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
 
         {/* Feed */}
         <div className="pb-10">

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -12,7 +12,6 @@ import {
 import { Fragment, useState } from "react";
 import { Article } from "./article";
 import { Pagination } from "./pagination";
-import { CategoryTag } from "./tag";
 
 const ENTRIES_PER_PAGE = 10;
 
@@ -113,13 +112,15 @@ export function ChangelogList({
       throw new Error("invariant");
     }
     datesGroupedByMonthAndYear.add(
-      changelogEntryPublishDateToAddressableTag(new Date(changelog.publishedAt)),
+      changelogEntryPublishDateToAddressableTag(
+        new Date(changelog.publishedAt),
+      ),
     );
   }
 
-  const sortedDatesGroupedByMonthAndYear = [
-    ...datesGroupedByMonthAndYear,
-  ].sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
+  const sortedDatesGroupedByMonthAndYear = [...datesGroupedByMonthAndYear].sort(
+    (a, b) => new Date(b).getTime() - new Date(a).getTime(),
+  );
 
   const numberOfPages = Math.ceil(filteredChangelogs.length / ENTRIES_PER_PAGE);
 
@@ -147,10 +148,10 @@ export function ChangelogList({
         <Fragment key={changelog.id}>
           {prevChangelogHasDifferentMonth && (
             <div className="flex items-center gap-3 mt-8 mb-4">
-              <span className="text-xs font-semibold uppercase tracking-widest text-blog-muted whitespace-nowrap">
+              <span className="text-xs font-semibold uppercase tracking-widest text-white/40 whitespace-nowrap">
                 {monthYear}
               </span>
-              <div className="flex-1 h-px bg-blog-border" />
+              <div className="flex-1 h-px bg-white/10" />
             </div>
           )}
           <Link href={`/changelog/${changelog.slug}`} className="block group">
@@ -172,11 +173,11 @@ export function ChangelogList({
     });
 
   return (
-    <main className="w-full bg-surface min-h-screen">
+    <main className="w-full bg-darkPurple min-h-screen">
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
-        {/* Filter bar */}
-        <div className="py-5 flex flex-col sm:flex-row sm:items-center gap-3 border-b border-blog-border">
-          {/* Category pills — scrollable on mobile */}
+        {/* Category nav — sticky, matches blog-category-nav */}
+        <div className="py-4 flex flex-col sm:flex-row sm:items-center gap-3 border-b border-white/10 sticky top-[4.5rem] z-30 bg-darkPurple">
+          {/* Category pills */}
           <div className="flex items-center gap-2 overflow-x-auto pb-1 sm:pb-0 flex-1 min-w-0">
             <button
               type="button"
@@ -184,10 +185,8 @@ export function ChangelogList({
                 setSelectedCategoriesIds(null);
                 setPageParam(null);
               }}
-              className={`flex-shrink-0 px-3 py-1 rounded-full text-sm font-medium transition-colors duration-150 border ${
-                selectedCategoriesIds.length === 0
-                  ? "bg-blog-accent text-white border-blog-accent"
-                  : "text-blog-muted border-blog-border hover:border-blog-accent hover:text-blog-accent"
+              className={`btn-new secondary-dark flex-shrink-0 !h-auto !py-1.5 !px-3 !text-[13px] ${
+                selectedCategoriesIds.length === 0 ? "!bg-[position:2%_0]" : ""
               }`}
             >
               All
@@ -213,10 +212,8 @@ export function ChangelogList({
                     }
                     setPageParam(null);
                   }}
-                  className={`flex-shrink-0 px-3 py-1 rounded-full text-sm font-medium transition-colors duration-150 border ${
-                    isActive
-                      ? "bg-blog-accent text-white border-blog-accent"
-                      : "text-blog-muted border-blog-border hover:border-blog-accent hover:text-blog-accent"
+                  className={`btn-new secondary-dark flex-shrink-0 !h-auto !py-1.5 !px-3 !text-[13px] ${
+                    isActive ? "!bg-[position:2%_0]" : ""
                   }`}
                 >
                   {category.name}
@@ -232,7 +229,7 @@ export function ChangelogList({
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"
-                className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-blog-muted pointer-events-none"
+                className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40 pointer-events-none"
                 aria-hidden="true"
               >
                 <path
@@ -252,13 +249,13 @@ export function ChangelogList({
                   setQuerySearchValue(newSearchValue);
                 }}
                 placeholder="Search..."
-                className="pl-8 pr-3 py-1.5 text-sm rounded-full border border-blog-border bg-white text-blog-text placeholder:text-blog-muted focus:outline-none focus:border-blog-accent focus:ring-1 focus:ring-blog-accent w-36 sm:w-44"
+                className="pl-8 pr-3 py-1.5 text-sm rounded-lg border border-white/25 bg-white/10 text-white placeholder:text-white/40 focus:outline-none focus:border-[#fd44b0] w-36 sm:w-44"
               />
             </div>
             {someFilterIsActive && (
               <button
                 type="button"
-                className="text-sm text-blog-muted hover:text-blog-accent transition-colors duration-150"
+                className="text-sm text-white/50 hover:text-white transition-colors duration-150"
                 onClick={() => {
                   setSearchValue(null);
                   setQuerySearchValue(null);
@@ -273,10 +270,10 @@ export function ChangelogList({
           </div>
         </div>
 
-        {/* Jump-to month — collapsible below filter bar on mobile, inline on desktop */}
+        {/* Jump-to month */}
         {sortedDatesGroupedByMonthAndYear.length > 0 && (
-          <div className="py-3 flex flex-wrap gap-x-4 gap-y-1 border-b border-blog-border">
-            <span className="text-xs font-semibold uppercase tracking-widest text-blog-muted self-center">
+          <div className="py-3 flex flex-wrap gap-x-4 gap-y-1 border-b border-white/10">
+            <span className="text-xs font-semibold uppercase tracking-widest text-white/40 self-center">
               Jump to:
             </span>
             {sortedDatesGroupedByMonthAndYear
@@ -302,8 +299,8 @@ export function ChangelogList({
                   }}
                   className={`text-xs transition-colors duration-150 ${
                     monthAndYearParam === monthAndYear
-                      ? "text-blog-accent font-semibold underline underline-offset-2"
-                      : "text-blog-muted hover:text-blog-accent"
+                      ? "text-[#fd44b0] font-semibold underline underline-offset-2"
+                      : "text-white/50 hover:text-white"
                   }`}
                 >
                   {monthAndYear}
@@ -318,9 +315,9 @@ export function ChangelogList({
 
           {paginatedChangelogs.length === 0 && (
             <div className="flex items-center gap-3 my-10">
-              <div className="flex-1 h-px bg-blog-border" />
-              <span className="text-sm text-blog-muted">No posts found.</span>
-              <div className="flex-1 h-px bg-blog-border" />
+              <div className="flex-1 h-px bg-white/10" />
+              <span className="text-sm text-white/40">No posts found.</span>
+              <div className="flex-1 h-px bg-white/10" />
             </div>
           )}
 

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -296,7 +296,7 @@ export function ChangelogList({
           {visibleMonths.length > 0 && (
             <div className="hidden sm:block w-40 flex-shrink-0">
               <div className="sticky top-[7rem] pt-6">
-                <span className="text-[10px] font-semibold uppercase tracking-widest text-white/35">
+                <span className="text-[10px] font-semibold uppercase tracking-widest text-white/60">
                   Jump to
                 </span>
                 <div className="mt-3 flex flex-col gap-2">
@@ -315,7 +315,7 @@ export function ChangelogList({
                       className={`text-left text-xs transition-colors duration-150 ${
                         monthAndYearParam === monthAndYear
                           ? "text-[#fd44b0] font-semibold"
-                          : "text-white/40 hover:text-white/80"
+                          : "text-white/65 hover:text-white"
                       }`}
                     >
                       {monthAndYear}

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -172,12 +172,14 @@ export function ChangelogList({
       );
     });
 
-  const visibleMonths = sortedDatesGroupedByMonthAndYear.filter((monthAndYear) =>
-    filteredChangelogsWithoutMonthFilter.some(
-      (changelog) =>
-        changelogEntryPublishDateToAddressableTag(new Date(changelog.publishedAt)) ===
-        monthAndYear,
-    ),
+  const visibleMonths = sortedDatesGroupedByMonthAndYear.filter(
+    (monthAndYear) =>
+      filteredChangelogsWithoutMonthFilter.some(
+        (changelog) =>
+          changelogEntryPublishDateToAddressableTag(
+            new Date(changelog.publishedAt),
+          ) === monthAndYear,
+      ),
   );
 
   return (

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -176,9 +176,9 @@ export function ChangelogList({
     <main className="w-full bg-darkPurple min-h-screen">
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
         {/* Category nav — sticky, matches blog-category-nav */}
-        <div className="py-4 flex flex-col sm:flex-row sm:items-center gap-3 border-b border-white/10 sticky top-[4.5rem] z-30 bg-darkPurple">
-          {/* Category pills */}
-          <div className="flex items-center gap-2 overflow-x-auto pb-1 sm:pb-0 flex-1 min-w-0">
+        <div className="py-4 flex items-center gap-3 border-b border-white/10 sticky top-[4.5rem] z-30 bg-darkPurple">
+          {/* Category pills — hidden on mobile */}
+          <div className="hidden sm:flex items-center gap-2 overflow-x-auto flex-1 min-w-0">
             <button
               type="button"
               onClick={() => {

--- a/src/client/components/list.tsx
+++ b/src/client/components/list.tsx
@@ -27,10 +27,6 @@ export type ChangelogEntry = {
   mdxSummary: MDXRemoteSerializeResult;
 };
 
-/**
- * Turns a date into this format: "August 2024"
- * Which is the format we use in query params and to filter.
- */
 function changelogEntryPublishDateToAddressableTag(date: Date) {
   return date.toLocaleString("en-EN", {
     month: "long",
@@ -66,62 +62,43 @@ export function ChangelogList({
   );
 
   const filteredChangelogsWithoutMonthFilter = changelogs
-    // First filter by categories
     .filter((changelog) => {
-      if (selectedCategoriesIds.length === 0) {
-        // If no categories are selected we don't filter anything
-        return true;
-      }
-
+      if (selectedCategoriesIds.length === 0) return true;
       return changelog.categories.some((changelogCategory) =>
         selectedCategoriesIds.includes(changelogCategory.id),
       );
     })
-
     .filter((changelog) => {
-      if (searchValue === null) {
-        return true;
-      }
-
+      if (searchValue === null) return true;
       const addressableDate = changelogEntryPublishDateToAddressableTag(
         new Date(changelog.publishedAt),
       );
-
-      // map all categories to a string
       const concatenatedCategories = changelog.categories
         .map((category: Category) => category.name)
         .join(" ");
-
       const searchableContent =
         changelog.title +
         changelog.summary +
         concatenatedCategories +
         addressableDate;
-
       return searchableContent
         .toLowerCase()
         .includes(searchValue.toLowerCase());
     })
-    .sort((a, b) => {
-      return (
-        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
-      );
-    });
+    .sort(
+      (a, b) =>
+        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+    );
 
-  const filteredChangelogs = filteredChangelogsWithoutMonthFilter
-    // Filter by selected date
-    .filter((changelog) => {
-      if (monthAndYearParam == null) {
-        // If no date was selected we don't filter anything
-        return true;
-      }
-
+  const filteredChangelogs = filteredChangelogsWithoutMonthFilter.filter(
+    (changelog) => {
+      if (monthAndYearParam == null) return true;
       const addressableDate = changelogEntryPublishDateToAddressableTag(
         new Date(changelog.publishedAt),
       );
-
       return monthAndYearParam === addressableDate;
-    });
+    },
+  );
 
   const allChangelogCategories: Record<string, Category> = {};
   for (const changelog of changelogs) {
@@ -130,23 +107,21 @@ export function ChangelogList({
     }
   }
 
-  // contains dates in the format "August 2024"
   const datesGroupedByMonthAndYear = new Set<string>();
   for (const changelog of changelogs) {
     if (changelog.publishedAt === null) {
       throw new Error("invariant");
     }
-
     datesGroupedByMonthAndYear.add(
-      changelogEntryPublishDateToAddressableTag(
-        new Date(changelog.publishedAt),
-      ),
+      changelogEntryPublishDateToAddressableTag(new Date(changelog.publishedAt)),
     );
   }
 
-  const sortedDatesGroupedByMonthAndYear = [...datesGroupedByMonthAndYear].sort(
-    (a, b) => new Date(b).getTime() - new Date(a).getTime(),
-  );
+  const sortedDatesGroupedByMonthAndYear = [
+    ...datesGroupedByMonthAndYear,
+  ].sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
+
+  const numberOfPages = Math.ceil(filteredChangelogs.length / ENTRIES_PER_PAGE);
 
   const paginatedChangelogs = filteredChangelogs
     .slice(
@@ -171,15 +146,15 @@ export function ChangelogList({
       return (
         <Fragment key={changelog.id}>
           {prevChangelogHasDifferentMonth && (
-            <div className="flex items-center my-4">
-              <div className="flex-1 border-t-[1px] border-gray-400" />
-              <span className="px-3 text-gray-500">{monthYear}</span>
-              <div className="flex-1 border-t-[1px] border-gray-400" />
+            <div className="flex items-center gap-3 mt-8 mb-4">
+              <span className="text-xs font-semibold uppercase tracking-widest text-blog-muted whitespace-nowrap">
+                {monthYear}
+              </span>
+              <div className="flex-1 h-px bg-blog-border" />
             </div>
           )}
-          <Link href={`/changelog/${changelog.slug}`}>
+          <Link href={`/changelog/${changelog.slug}`} className="block group">
             <Article
-              className="fancy-border"
               key={changelog.id}
               slug={changelog.slug}
               date={changelog.publishedAt}
@@ -196,69 +171,94 @@ export function ChangelogList({
       );
     });
 
-  const numberOfPages = Math.ceil(filteredChangelogs.length / ENTRIES_PER_PAGE);
-
   return (
-    <main className="w-full mx-auto grid grid-cols-12 bg-gray-200">
-      <div className="hidden md:block md:col-span-2 pl-5 pt-10">
-        <h3 className="text-2xl text-primary font-semibold mb-2">
-          Categories:
-        </h3>
-        <div className="flex flex-wrap gap-1 py-1">
-          {Object.values(allChangelogCategories).map((category) => {
-            return (
-              <CategoryTag
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (selectedCategoriesIds.includes(category.id)) {
-                    const newSelectedCategoriesIds =
-                      selectedCategoriesIds.filter(
-                        (cat) => cat !== category.id,
-                      );
-                    setSelectedCategoriesIds(newSelectedCategoriesIds);
-                    setPageParam(null);
-                  } else {
-                    setSelectedCategoriesIds([
-                      ...selectedCategoriesIds,
-                      category.id,
-                    ]);
-                    setPageParam(null);
-                  }
-                }}
-                text={category.name}
-                active={selectedCategoriesIds.includes(category.id)}
-                pointer
-                key={category.name}
-              />
-            );
-          })}
-        </div>
-      </div>
-      <div className="col-span-12 md:col-span-8">
-        <div className="max-w-3xl mx-auto px-4 pb-4 sm:px-6 md:px-8">
-          <div className="flex justify-between items-center py-6 space-x-4">
-            <input
-              aria-label="Search..."
-              type="text"
-              value={searchValue ?? ""}
-              onChange={(e) => {
+    <main className="w-full bg-surface min-h-screen">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6">
+        {/* Filter bar */}
+        <div className="py-5 flex flex-col sm:flex-row sm:items-center gap-3 border-b border-blog-border">
+          {/* Category pills — scrollable on mobile */}
+          <div className="flex items-center gap-2 overflow-x-auto pb-1 sm:pb-0 flex-1 min-w-0">
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedCategoriesIds(null);
                 setPageParam(null);
-                const newSearchValue = e.target.value ? e.target.value : null;
-                setSearchValue(newSearchValue);
-                setQuerySearchValue(newSearchValue);
               }}
-              placeholder="Search..."
-              className="form-input flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500"
-            />
-            <div className="flex space-x-4">
+              className={`flex-shrink-0 px-3 py-1 rounded-full text-sm font-medium transition-colors duration-150 border ${
+                selectedCategoriesIds.length === 0
+                  ? "bg-blog-accent text-white border-blog-accent"
+                  : "text-blog-muted border-blog-border hover:border-blog-accent hover:text-blog-accent"
+              }`}
+            >
+              All
+            </button>
+            {Object.values(allChangelogCategories).map((category) => {
+              const isActive = selectedCategoriesIds.includes(category.id);
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  onClick={() => {
+                    if (isActive) {
+                      setSelectedCategoriesIds(
+                        selectedCategoriesIds.filter(
+                          (id) => id !== category.id,
+                        ),
+                      );
+                    } else {
+                      setSelectedCategoriesIds([
+                        ...selectedCategoriesIds,
+                        category.id,
+                      ]);
+                    }
+                    setPageParam(null);
+                  }}
+                  className={`flex-shrink-0 px-3 py-1 rounded-full text-sm font-medium transition-colors duration-150 border ${
+                    isActive
+                      ? "bg-blog-accent text-white border-blog-accent"
+                      : "text-blog-muted border-blog-border hover:border-blog-accent hover:text-blog-accent"
+                  }`}
+                >
+                  {category.name}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Search + Reset */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="relative">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-blog-muted pointer-events-none"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <input
+                aria-label="Search..."
+                type="text"
+                value={searchValue ?? ""}
+                onChange={(e) => {
+                  setPageParam(null);
+                  const newSearchValue = e.target.value ? e.target.value : null;
+                  setSearchValue(newSearchValue);
+                  setQuerySearchValue(newSearchValue);
+                }}
+                placeholder="Search..."
+                className="pl-8 pr-3 py-1.5 text-sm rounded-full border border-blog-border bg-white text-blog-text placeholder:text-blog-muted focus:outline-none focus:border-blog-accent focus:ring-1 focus:ring-blog-accent w-36 sm:w-44"
+              />
+            </div>
+            {someFilterIsActive && (
               <button
-                tabIndex={0}
                 type="button"
-                className={`${
-                  someFilterIsActive
-                    ? "text-purple font-medium cursor-pointer"
-                    : "text-gray-500 cursor-not-allowed"
-                } hover:text-gray-700 bg-transparent border-none`}
+                className="text-sm text-blog-muted hover:text-blog-accent transition-colors duration-150"
                 onClick={() => {
                   setSearchValue(null);
                   setQuerySearchValue(null);
@@ -269,72 +269,77 @@ export function ChangelogList({
               >
                 Reset
               </button>
-            </div>
+            )}
           </div>
+        </div>
 
+        {/* Jump-to month — collapsible below filter bar on mobile, inline on desktop */}
+        {sortedDatesGroupedByMonthAndYear.length > 0 && (
+          <div className="py-3 flex flex-wrap gap-x-4 gap-y-1 border-b border-blog-border">
+            <span className="text-xs font-semibold uppercase tracking-widest text-blog-muted self-center">
+              Jump to:
+            </span>
+            {sortedDatesGroupedByMonthAndYear
+              .filter((monthAndYear) =>
+                filteredChangelogsWithoutMonthFilter.some(
+                  (changelog) =>
+                    changelogEntryPublishDateToAddressableTag(
+                      new Date(changelog.publishedAt),
+                    ) === monthAndYear,
+                ),
+              )
+              .map((monthAndYear) => (
+                <button
+                  key={monthAndYear}
+                  type="button"
+                  onClick={() => {
+                    if (monthAndYearParam === monthAndYear) {
+                      setMonthParam(null);
+                    } else {
+                      setMonthParam(monthAndYear);
+                    }
+                    setPageParam(null);
+                  }}
+                  className={`text-xs transition-colors duration-150 ${
+                    monthAndYearParam === monthAndYear
+                      ? "text-blog-accent font-semibold underline underline-offset-2"
+                      : "text-blog-muted hover:text-blog-accent"
+                  }`}
+                >
+                  {monthAndYear}
+                </button>
+              ))}
+          </div>
+        )}
+
+        {/* Feed */}
+        <div className="pb-10">
           {paginatedChangelogs}
 
-          {numberOfPages > 1 && (
-            <Pagination
-              currentPage={selectedPage}
-              totalPages={numberOfPages}
-              onPageNumberChange={(pageNumber) => {
-                setPageParam(pageNumber, { history: "push" });
-              }}
-              search={searchValue}
-              selectedMonth={monthAndYearParam}
-              selectedCategoriesIds={selectedCategoriesIds}
-            />
+          {paginatedChangelogs.length === 0 && (
+            <div className="flex items-center gap-3 my-10">
+              <div className="flex-1 h-px bg-blog-border" />
+              <span className="text-sm text-blog-muted">No posts found.</span>
+              <div className="flex-1 h-px bg-blog-border" />
+            </div>
           )}
 
-          {paginatedChangelogs.length === 0 && (
-            <div className="flex items-center my-4">
-              <div className="flex-1 border-t-[1px] border-gray-400" />
-              <span className="px-3 text-gray-500">No posts found.</span>
-              <div className="flex-1 border-t-[1px] border-gray-400" />
+          {numberOfPages > 1 && (
+            <div className="mt-8">
+              <Pagination
+                currentPage={selectedPage}
+                totalPages={numberOfPages}
+                onPageNumberChange={(pageNumber) => {
+                  setPageParam(pageNumber, { history: "push" });
+                }}
+                search={searchValue}
+                selectedMonth={monthAndYearParam}
+                selectedCategoriesIds={selectedCategoriesIds}
+              />
             </div>
           )}
         </div>
       </div>
-      <nav
-        className="hidden md:block md:col-span-2 pl-5 pt-10"
-        aria-label="Jump to month and year"
-      >
-        <h3 className="text-1xl text-primary font-semibold mb-2">Jump to:</h3>
-        <ul>
-          {sortedDatesGroupedByMonthAndYear
-            .filter((monthAndYear) => {
-              return filteredChangelogsWithoutMonthFilter.some((changelog) => {
-                return (
-                  changelogEntryPublishDateToAddressableTag(
-                    new Date(changelog.publishedAt),
-                  ) === monthAndYear
-                );
-              });
-            })
-            .map((monthAndYear) => (
-              <li key={monthAndYear}>
-                <button
-                  type="button"
-                  className={`text-primary cursor-pointer hover:text-purple-900 hover:font-extrabold bg-transparent border-none ${
-                    monthAndYearParam === monthAndYear ? "underline" : ""
-                  }`}
-                  onClick={() => {
-                    if (monthAndYearParam === monthAndYear) {
-                      setMonthParam(null);
-                      setPageParam(null);
-                    } else {
-                      setMonthParam(monthAndYear);
-                      setPageParam(null);
-                    }
-                  }}
-                >
-                  {monthAndYear}
-                </button>
-              </li>
-            ))}
-        </ul>
-      </nav>
     </main>
   );
 }

--- a/src/client/components/pagination.tsx
+++ b/src/client/components/pagination.tsx
@@ -65,7 +65,7 @@ export function Pagination({
       >
         <button
           disabled={!navigationToPrevPageAllowed}
-          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-white uppercase align-middle transition-all rounded-lg select-none hover:bg-darkPurple/10 active:bg-darkPurple disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-white uppercase align-middle transition-all rounded-lg select-none hover:bg-white/10 active:bg-white/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
           type="button"
         >
           <svg
@@ -107,8 +107,8 @@ export function Pagination({
             <button
               className={`${
                 page === currentPage
-                  ? "bg-darkPurple relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg  text-center align-middle font-sans text-xs font-medium uppercase text-white shadow-md  hover:shadow-lg hover:bg-darkPurple focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
-                  : "relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg text-center align-middle font-sans text-xs font-medium uppercase text-white hover:bg-darkPurple/10 active:bg-darkPurple/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+                  ? "bg-white/20 relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg text-center align-middle font-sans text-xs font-medium uppercase text-white shadow-md hover:bg-white/25 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+                  : "relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg text-center align-middle font-sans text-xs font-medium uppercase text-white hover:bg-white/10 active:bg-white/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
               }`}
               type="button"
             >
@@ -135,7 +135,7 @@ export function Pagination({
       >
         <button
           disabled={!navigationToNextPageAllowed}
-          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-white uppercase align-middle rounded-lg select-none hover:bg-darkPurple/10 active:bg-darkPurple/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-white uppercase align-middle rounded-lg select-none hover:bg-white/10 active:bg-white/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
           type="button"
         >
           Next

--- a/src/client/components/pagination.tsx
+++ b/src/client/components/pagination.tsx
@@ -65,7 +65,7 @@ export function Pagination({
       >
         <button
           disabled={!navigationToPrevPageAllowed}
-          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-gray-900 uppercase align-middle transition-all rounded-lg select-none hover:bg-darkPurple/10 active:bg-darkPurple disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-white uppercase align-middle transition-all rounded-lg select-none hover:bg-darkPurple/10 active:bg-darkPurple disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
           type="button"
         >
           <svg
@@ -108,7 +108,7 @@ export function Pagination({
               className={`${
                 page === currentPage
                   ? "bg-darkPurple relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg  text-center align-middle font-sans text-xs font-medium uppercase text-white shadow-md  hover:shadow-lg hover:bg-darkPurple focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
-                  : "relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg text-center align-middle font-sans text-xs font-medium uppercase text-gray-900 hover:bg-darkPurple/10 active:bg-darkPurple/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+                  : "relative h-10 max-h-[40px] w-10 max-w-[40px] select-none rounded-lg text-center align-middle font-sans text-xs font-medium uppercase text-white hover:bg-darkPurple/10 active:bg-darkPurple/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
               }`}
               type="button"
             >
@@ -135,7 +135,7 @@ export function Pagination({
       >
         <button
           disabled={!navigationToNextPageAllowed}
-          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-gray-900 uppercase align-middle rounded-lg select-none hover:bg-darkPurple/10 active:bg-darkPurple/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+          className="hidden md:flex items-center gap-2 px-6 py-3 font-sans text-xs font-bold text-center text-white uppercase align-middle rounded-lg select-none hover:bg-darkPurple/10 active:bg-darkPurple/20 disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
           type="button"
         >
           Next

--- a/src/client/components/shareButtons.tsx
+++ b/src/client/components/shareButtons.tsx
@@ -1,23 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function ShareButtons({ title, slug }: { title: string; slug: string }) {
   const [copied, setCopied] = useState(false);
+  const [url, setUrl] = useState(`https://sentry.io/changelog/${slug}`);
 
-  const url =
-    typeof window !== "undefined"
-      ? `${window.location.origin}/changelog/${slug}`
-      : `https://sentry.io/changelog/${slug}`;
+  useEffect(() => {
+    setUrl(`${window.location.origin}/changelog/${slug}`);
+  }, [slug]);
 
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
 
   function handleCopy() {
-    navigator.clipboard.writeText(url).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
   }
 
   return (

--- a/src/client/components/shareButtons.tsx
+++ b/src/client/components/shareButtons.tsx
@@ -27,6 +27,7 @@ export function ShareButtons({ title, slug }: { title: string; slug: string }) {
       </span>
 
       {/* X / Twitter */}
+      {/* biome-ignore lint/a11y/useAnchorContent: aria-label provides accessible content */}
       <a
         href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`}
         target="_blank"
@@ -46,6 +47,7 @@ export function ShareButtons({ title, slug }: { title: string; slug: string }) {
       </a>
 
       {/* LinkedIn */}
+      {/* biome-ignore lint/a11y/useAnchorContent: aria-label provides accessible content */}
       <a
         href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`}
         target="_blank"
@@ -65,6 +67,7 @@ export function ShareButtons({ title, slug }: { title: string; slug: string }) {
       </a>
 
       {/* Hacker News */}
+      {/* biome-ignore lint/a11y/useAnchorContent: aria-label provides accessible content */}
       <a
         href={`https://news.ycombinator.com/submitlink?u=${encodedUrl}&t=${encodedTitle}`}
         target="_blank"

--- a/src/client/components/shareButtons.tsx
+++ b/src/client/components/shareButtons.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+
+export function ShareButtons({ title, slug }: { title: string; slug: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const url =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/changelog/${slug}`
+      : `https://sentry.io/changelog/${slug}`;
+
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-blog-muted font-medium uppercase tracking-wide mr-1">
+        Share
+      </span>
+
+      {/* X / Twitter */}
+      <a
+        href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on X (Twitter)"
+        className="p-1.5 rounded-md text-blog-muted hover:text-blog-text hover:bg-surface-overlay transition-colors duration-150"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      </a>
+
+      {/* LinkedIn */}
+      <a
+        href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on LinkedIn"
+        className="p-1.5 rounded-md text-blog-muted hover:text-blog-text hover:bg-surface-overlay transition-colors duration-150"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+      </a>
+
+      {/* Hacker News */}
+      <a
+        href={`https://news.ycombinator.com/submitlink?u=${encodedUrl}&t=${encodedTitle}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on Hacker News"
+        className="p-1.5 rounded-md text-blog-muted hover:text-blog-text hover:bg-surface-overlay transition-colors duration-150"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path d="M0 24V0h24v24H0zM6.951 5.896l4.112 7.708v5.064h1.583v-4.972l4.148-7.799h-1.749l-2.457 4.875c-.372.745-.688 1.434-.688 1.434s-.297-.708-.651-1.434L8.831 5.896H6.95z" />
+        </svg>
+      </a>
+
+      {/* Copy link */}
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label="Copy link"
+        className="p-1.5 rounded-md text-blog-muted hover:text-blog-text hover:bg-surface-overlay transition-colors duration-150"
+      >
+        {copied ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-4 h-4 text-green-500"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+              clipRule="evenodd"
+            />
+          </svg>
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-4 h-4"
+            aria-hidden="true"
+          >
+            <path d="M12.232 4.232a2.5 2.5 0 013.536 3.536l-1.225 1.224a.75.75 0 001.061 1.06l1.224-1.224a4 4 0 00-5.656-5.656l-3 3a4 4 0 00.225 5.865.75.75 0 00.977-1.138 2.5 2.5 0 01-.142-3.667l3-3z" />
+            <path d="M11.603 7.963a.75.75 0 00-.977 1.138 2.5 2.5 0 01.142 3.667l-3 3a2.5 2.5 0 01-3.536-3.536l1.225-1.224a.75.75 0 00-1.061-1.06l-1.224 1.224a4 4 0 105.656 5.656l3-3a4 4 0 00-.225-5.865z" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/client/components/tableOfContents.tsx
+++ b/src/client/components/tableOfContents.tsx
@@ -70,9 +70,7 @@ export function TableOfContents({
             <a
               href={`#${heading.id}`}
               className={`text-sm leading-snug transition-colors duration-150 hover:text-blog-accent ${
-                activeId === heading.id
-                  ? "toc-link-active"
-                  : "text-blog-muted"
+                activeId === heading.id ? "toc-link-active" : "text-blog-muted"
               }`}
               onClick={(e) => {
                 e.preventDefault();

--- a/src/client/components/tableOfContents.tsx
+++ b/src/client/components/tableOfContents.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Heading = {
+  id: string;
+  text: string;
+  level: number;
+};
+
+function getHeadings(contentSelector: string): Heading[] {
+  const container = document.querySelector(contentSelector);
+  if (!container) return [];
+  const nodes = container.querySelectorAll("h2, h3");
+  return Array.from(nodes).map((node) => ({
+    id: node.id,
+    text: node.textContent ?? "",
+    level: Number(node.tagName.slice(1)),
+  }));
+}
+
+export function TableOfContents({
+  contentSelector = ".blog-content",
+}: {
+  contentSelector?: string;
+}) {
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [activeId, setActiveId] = useState<string>("");
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const h = getHeadings(contentSelector);
+    setHeadings(h);
+    if (h.length === 0) return;
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -60% 0px", threshold: 0.1 },
+    );
+
+    for (const heading of h) {
+      const el = document.getElementById(heading.id);
+      if (el) observerRef.current.observe(el);
+    }
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [contentSelector]);
+
+  if (headings.length === 0) return null;
+
+  return (
+    <nav aria-label="Table of contents">
+      <p className="text-xs font-semibold uppercase tracking-widest text-blog-muted mb-3">
+        On this page
+      </p>
+      <ul className="space-y-1.5">
+        {headings.map((heading) => (
+          <li
+            key={heading.id}
+            style={{ paddingLeft: heading.level === 3 ? "0.75rem" : "0" }}
+          >
+            <a
+              href={`#${heading.id}`}
+              className={`text-sm leading-snug transition-colors duration-150 hover:text-blog-accent ${
+                activeId === heading.id
+                  ? "toc-link-active"
+                  : "text-blog-muted"
+              }`}
+              onClick={(e) => {
+                e.preventDefault();
+                document
+                  .getElementById(heading.id)
+                  ?.scrollIntoView({ behavior: "smooth" });
+                setActiveId(heading.id);
+              }}
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/client/components/tag.tsx
+++ b/src/client/components/tag.tsx
@@ -13,13 +13,17 @@ export function CategoryTag({
   pointer,
   onClick,
 }: CategoryTagProps) {
+  const base =
+    "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium uppercase tracking-wide transition-colors duration-150";
+  const activeStyle = "bg-blog-accent text-white";
+  const inactiveStyle =
+    "bg-surface-overlay text-blog-accent border border-blog-border hover:bg-blog-accent hover:text-white";
+
   if (pointer && onClick) {
     return (
       <button
         type="button"
-        className={`py-1 px-3 uppercase shadow-sm no-underline rounded-full text-red text-xs mr-2 cursor-pointer ${
-          active ? "bg-gray-300" : "bg-gray-100"
-        }`}
+        className={`${base} ${active ? activeStyle : inactiveStyle} cursor-pointer`}
         onClick={onClick}
       >
         {text.split(" ").join("-")}
@@ -28,12 +32,8 @@ export function CategoryTag({
   }
 
   return (
-    <div
-      className={`py-1 px-3 uppercase shadow-sm no-underline rounded-full text-red text-xs mr-2 ${
-        active ? "bg-gray-300" : "bg-gray-100"
-      }`}
-    >
+    <span className={`${base} ${active ? activeStyle : inactiveStyle}`}>
       {text.split(" ").join("-")}
-    </div>
+    </span>
   );
 }

--- a/src/client/components/tag.tsx
+++ b/src/client/components/tag.tsx
@@ -7,23 +7,15 @@ type CategoryTagProps = {
   onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export function CategoryTag({
-  text,
-  active,
-  pointer,
-  onClick,
-}: CategoryTagProps) {
+export function CategoryTag({ text, pointer, onClick }: CategoryTagProps) {
   const base =
-    "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium uppercase tracking-wide transition-colors duration-150";
-  const activeStyle = "bg-blog-accent text-white";
-  const inactiveStyle =
-    "bg-surface-overlay text-blog-accent border border-blog-border hover:bg-blog-accent hover:text-white";
+    "text-[0.6875rem] font-medium uppercase tracking-[.06em] text-[#fd44b0] inline-block transition-opacity duration-150 hover:opacity-70";
 
   if (pointer && onClick) {
     return (
       <button
         type="button"
-        className={`${base} ${active ? activeStyle : inactiveStyle} cursor-pointer`}
+        className={`${base} cursor-pointer`}
         onClick={onClick}
       >
         {text.split(" ").join("-")}
@@ -31,9 +23,5 @@ export function CategoryTag({
     );
   }
 
-  return (
-    <span className={`${base} ${active ? activeStyle : inactiveStyle}`}>
-      {text.split(" ").join("-")}
-    </span>
-  );
+  return <span className={base}>{text.split(" ").join("-")}</span>;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -77,6 +77,7 @@ module.exports = {
         'blog-accent-hover': '#5A4FB1',
         'blog-pink': '#E1567C',
         'blog-gold': '#F2B712',
+        'hot-pink': '#fd44b0',
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -66,6 +66,17 @@ module.exports = {
         pink: {
           500: '#F472B6',
         },
+        // Blog-aligned palette
+        surface: '#FFFFFF',
+        'surface-raised': '#F9F8FF',
+        'surface-overlay': '#F3F2FA',
+        'blog-border': '#E8E5F0',
+        'blog-text': '#1D1127',
+        'blog-muted': '#6B6580',
+        'blog-accent': '#6A5FC1',
+        'blog-accent-hover': '#5A4FB1',
+        'blog-pink': '#E1567C',
+        'blog-gold': '#F2B712',
       },
     },
   },


### PR DESCRIPTION
- Replace dark purple diagonal hero with clean flat header (RSS pill CTA)
- Remove three-column grid; use centered max-w-4xl single-column feed
- Add horizontal scrollable category pill filter bar above the feed
- Move month jump-to nav inline below filter bar (compact row)
- Restyle article cards: border/shadow on hover, aspect-video image,
  category pills, clamped summary, "Read more →" text link
- Restyle CategoryTag to match blog-style pill (accent color, hover fill)
- Add blog-aligned Tailwind color tokens (surface, blog-border, blog-muted,
  blog-accent, etc.) to tailwind.config.ts
- Add blog-prose CSS overrides: violet left-border on h2, link color,
  TOC active state
- Detail page: full-bleed hero image, two-column layout with sticky TOC
  sidebar on desktop, metadata strip (date · read time), share buttons
  (X, LinkedIn, HN, copy link), plain "← Changelog" back link
- New TableOfContents client component using IntersectionObserver
- New ShareButtons client component (X, LinkedIn, HN, copy-link)
- Add related entries section (3 most recent other entries)
- Update layout.tsx: white background, clean border-top footer,
  violet progress bar
- Update loading.tsx skeletons to match new layout

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>