### PR TITLE
Add broadcastCategory field to changelog entries

### DIFF
--- a/content/changelog/README.md
+++ b/content/changelog/README.md
@@ -49,6 +49,7 @@ Body content here…
 | `date`       | no       | `YYYY-MM-DD`. Controls ordering. Defaults to merge date if published. |
 | `author`     | no       | Email of an existing user to attribute.                               |
 | `platform`   | no       | List of Sentry platform slugs (e.g. `javascript-react`, `python-django`). Scopes getsentry broadcast targeting to matching orgs. Empty = all platforms. Valid slugs are in `src/lib/platforms.ts`. |
+| `broadcastCategory` | no | Controls the label pill in Sentry's "What's New" panel. One of: `announcement`, `feature`, `sdk_update`. Defaults to `feature` when omitted. |
 | `deleted`    | no       | Set `true` to unpublish/soft-delete while keeping the file as a record. |
 
 Files starting with `_` (like `_template.md`) or `.` are ignored.

--- a/content/changelog/_template.md
+++ b/content/changelog/_template.md
@@ -26,6 +26,11 @@ categories:
 platform:
   - javascript-react
 
+# Optional. Controls the label pill in Sentry's "What's New" broadcast panel.
+# Valid values: announcement, feature, sdk_update
+# Defaults to "feature" (New Feature) when omitted or null.
+# broadcastCategory: announcement
+
 # Optional. Defaults to false. Set to true to make the entry live.
 published: false
 

--- a/scripts/changelog/lib.mjs
+++ b/scripts/changelog/lib.mjs
@@ -173,6 +173,18 @@ export function validateEntries(entries) {
       errors.push(`${prefix} "author" must be an email string`);
     }
 
+    if (frontmatter.broadcastCategory !== undefined) {
+      const validCategories = ["announcement", "feature", "sdk_update"];
+      if (
+        typeof frontmatter.broadcastCategory !== "string" ||
+        !validCategories.includes(frontmatter.broadcastCategory)
+      ) {
+        errors.push(
+          `${prefix} "broadcastCategory" must be one of: ${validCategories.join(", ")}`,
+        );
+      }
+    }
+
     if (frontmatter.platform !== undefined) {
       if (
         !Array.isArray(frontmatter.platform) ||

--- a/scripts/changelog/sync.ts
+++ b/scripts/changelog/sync.ts
@@ -35,6 +35,7 @@ type ChangelogFileEntry = {
     published?: boolean;
     categories?: string[];
     platform?: string[];
+    broadcastCategory?: string;
     author?: string;
   };
   content: string;
@@ -138,6 +139,17 @@ async function syncEntry(
     ? frontmatter.platform.filter((p) => typeof p === "string")
     : [];
 
+  const validBroadcastCategories = new Set([
+    "announcement",
+    "feature",
+    "sdk_update",
+  ]);
+  const broadcastCategory =
+    typeof frontmatter.broadcastCategory === "string" &&
+    validBroadcastCategories.has(frontmatter.broadcastCategory)
+      ? frontmatter.broadcastCategory
+      : null;
+
   const common = {
     title: frontmatter.title,
     content,
@@ -149,6 +161,7 @@ async function syncEntry(
     publishedAt,
     slug,
     platform: platformSlugs,
+    broadcastCategory,
   };
 
   const [changelog] = await tx

--- a/src/app/api/changelogs/[slug]/route.ts
+++ b/src/app/api/changelogs/[slug]/route.ts
@@ -21,6 +21,7 @@ export async function GET(
         content: Changelog.content,
         publishedAt: Changelog.publishedAt,
         platform: Changelog.platform,
+        broadcastCategory: Changelog.broadcastCategory,
       })
       .from(Changelog)
       .where(

--- a/src/app/api/changelogs/route.test.ts
+++ b/src/app/api/changelogs/route.test.ts
@@ -155,6 +155,7 @@ describe("GET /api/changelogs", () => {
         content: Changelog.content,
         publishedAt: Changelog.publishedAt,
         platform: Changelog.platform,
+        broadcastCategory: Changelog.broadcastCategory,
       });
     });
   });

--- a/src/app/api/changelogs/route.ts
+++ b/src/app/api/changelogs/route.ts
@@ -99,6 +99,7 @@ export async function GET(request: Request) {
         content: Changelog.content,
         publishedAt: Changelog.publishedAt,
         platform: Changelog.platform,
+        broadcastCategory: Changelog.broadcastCategory,
       })
       .from(Changelog)
       .where(and(...whereClauses))

--- a/src/client/components/forms/createChangelogForm.tsx
+++ b/src/client/components/forms/createChangelogForm.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useActionState } from "react";
+import ReactSelect from "react-select";
 import { FileUpload } from "@/client/components/fileUpload";
 import { ForwardRefEditor } from "@/client/components/forwardRefEditor";
 import { TitleSlug } from "@/client/components/titleSlug";
@@ -9,6 +10,13 @@ import { Button } from "@/client/components/ui/Button";
 import { Select } from "@/client/components/ui/Select";
 import { PLATFORM_GROUPS } from "@/lib/platforms";
 import { createChangelog } from "@/server/actions/changelog";
+
+const BROADCAST_CATEGORY_OPTIONS = [
+  { label: "New Feature", value: "feature" },
+  { label: "Announcement", value: "announcement" },
+  { label: "SDK Update", value: "sdk_update" },
+];
+
 import type { CategoryModel as Category } from "@/server/db/schema";
 
 export const CreateChangelogForm = ({
@@ -60,6 +68,25 @@ export const CreateChangelogForm = ({
         <span className="text-xs text-gray-500 italic">
           Scopes auto-generated broadcasts to these Sentry platforms. Leave
           empty to target all platforms.
+        </span>
+      </div>
+
+      <div className="mb-6">
+        <label
+          htmlFor="broadcastCategory"
+          className="block text-xs font-medium text-gray-700"
+        >
+          Broadcast Label (shown in &quot;What&apos;s New&quot;)
+        </label>
+        <ReactSelect
+          name="broadcastCategory"
+          placeholder="Defaults to New Feature"
+          options={BROADCAST_CATEGORY_OPTIONS}
+          isClearable
+        />
+        <span className="text-xs text-gray-500 italic">
+          Controls the label pill in Sentry&apos;s &quot;What&apos;s New&quot;
+          panel
         </span>
       </div>
 

--- a/src/client/components/forms/editChangelogForm.tsx
+++ b/src/client/components/forms/editChangelogForm.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { Suspense, useActionState } from "react";
+import ReactSelect from "react-select";
 import { FileUpload } from "@/client/components/fileUpload";
 import { ForwardRefEditor } from "@/client/components/forwardRefEditor";
 import { TitleSlug } from "@/client/components/titleSlug";
@@ -9,6 +10,13 @@ import { Button } from "@/client/components/ui/Button";
 import { Select } from "@/client/components/ui/Select";
 import { PLATFORM_GROUPS, platformLabel } from "@/lib/platforms";
 import { editChangelog } from "@/server/actions/changelog";
+
+const BROADCAST_CATEGORY_OPTIONS = [
+  { label: "New Feature", value: "feature" },
+  { label: "Announcement", value: "announcement" },
+  { label: "SDK Update", value: "sdk_update" },
+];
+
 import type {
   CategoryModel as Category,
   ChangelogModel as Changelog,
@@ -76,6 +84,35 @@ export const EditChangelogForm = ({
         <span className="text-xs text-gray-500 italic">
           Scopes auto-generated broadcasts to these Sentry platforms. Leave
           empty to target all platforms.
+        </span>
+      </div>
+
+      <div className="mb-6">
+        <label
+          htmlFor="broadcastCategory"
+          className="block text-xs font-medium text-gray-700"
+        >
+          Broadcast Label (shown in &quot;What&apos;s New&quot;)
+        </label>
+        {/* Sentinel so the server action knows the field was rendered,
+            even when react-select removes its hidden input on clear. */}
+        <input type="hidden" name="broadcastCategoryPresent" value="1" />
+        <ReactSelect
+          name="broadcastCategory"
+          placeholder="Defaults to New Feature"
+          options={BROADCAST_CATEGORY_OPTIONS}
+          defaultValue={
+            changelog.broadcastCategory
+              ? BROADCAST_CATEGORY_OPTIONS.find(
+                  (o) => o.value === changelog.broadcastCategory,
+                )
+              : undefined
+          }
+          isClearable
+        />
+        <span className="text-xs text-gray-500 italic">
+          Controls the label pill in Sentry&apos;s &quot;What&apos;s New&quot;
+          panel
         </span>
       </div>
 

--- a/src/server/actions/changelog.ts
+++ b/src/server/actions/changelog.ts
@@ -10,6 +10,20 @@ import { db } from "../db";
 import { _CategoryToChangelog, Category, Changelog, User } from "../db/schema";
 import type { ServerActionPayloadInterface } from "./serverActionPayload.interface";
 
+const VALID_BROADCAST_CATEGORIES = new Set([
+  "announcement",
+  "feature",
+  "sdk_update",
+]);
+
+function parseBroadcastCategory(formData: FormData): string | null {
+  const raw = formData.get("broadcastCategory");
+  if (typeof raw === "string" && VALID_BROADCAST_CATEGORIES.has(raw)) {
+    return raw;
+  }
+  return null;
+}
+
 // Keep only known Sentry platform slugs; the form's select is already
 // constrained, but guard against stale/forged values reaching the database.
 function parsePlatforms(formData: FormData): string[] {
@@ -169,6 +183,7 @@ export async function createChangelog(
       image: formData.get("image") as string,
       slug: formData.get("slug") as string,
       platform: parsePlatforms(formData),
+      broadcastCategory: parseBroadcastCategory(formData),
       // Created in the UI, so the UI owns it; the file sync will never touch it.
       adminManaged: true,
       // Explicitly null so publishChangelog can distinguish a never-published
@@ -215,6 +230,14 @@ export async function editChangelog(
         image: formData.get("image") as string,
         slug: formData.get("slug") as string,
         platform: parsePlatforms(formData),
+        // A sentinel hidden input (broadcastCategoryPresent) is always submitted
+        // by the edit form, even when react-select removes its own hidden input
+        // after the user clears the dropdown. This distinguishes "field was
+        // rendered but cleared" (write null) from "field was never on the page"
+        // (preserve existing value).
+        ...(formData.has("broadcastCategoryPresent")
+          ? { broadcastCategory: parseBroadcastCategory(formData) }
+          : {}),
         // Edited in the UI, so the UI now owns it; future file syncs skip it.
         adminManaged: true,
       })

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -110,6 +110,7 @@ export const Changelog = pgTable(
     deleted: boolean("deleted").notNull().default(false),
     adminManaged: boolean("adminManaged").notNull().default(false),
     platform: text("platform").array().notNull().default([]),
+    broadcastCategory: text("broadcastCategory"),
     authorId: text("authorId").references(() => User.id, {
       onDelete: "set null",
       onUpdate: "cascade",


### PR DESCRIPTION
## Summary

Adds a `broadcastCategory` field to changelog entries so authors can explicitly control the label pill shown in Sentry's "What's New" broadcast panel.

## Problem

The sync job in getsentry that creates Sentry broadcasts from changelog entries hardcodes `category: "feature"` for every entry. This means everything shows up as "New Feature" in the What's New panel — even entries like "Codecov in Sentry has been removed" which should be labeled "Announcement".

The changelog admin UI had no field to control this.

## Solution

Add a `BroadcastCategory` Prisma enum with the 5 valid broadcast categories (`announcement`, `feature`, `blog`, `event`, `video`) and an optional `broadcastCategory` column on the `Changelog` model.

### Changes

| File | Change |
|------|--------|
| `prisma/schema.prisma` | Add `BroadcastCategory` enum and nullable column |
| `prisma/migrations/2025…/migration.sql` | `CREATE TYPE` + `ALTER TABLE ADD COLUMN` |
| `src/server/actions/changelog.ts` | Read `broadcastCategory` from form data in create + edit |
| `src/client/components/forms/createChangelogForm.tsx` | Add broadcast label dropdown (non-creatable, fixed options) |
| `src/client/components/forms/editChangelogForm.tsx` | Add broadcast label dropdown with default value from existing entry |
| `src/app/api/changelogs/route.ts` | Include `broadcastCategory` in API response |

### Backward compatible

- Existing rows get `NULL` — no data migration needed
- The getsentry sync job falls back to `"feature"` when the field is null/absent (no behavior change)
- The API response gains a new field; consumers that don't read it are unaffected

### Companion PR

- getsentry/getsentry — honors the `broadcastCategory` field in the broadcast sync task (`_process_entry`)

Deploy this PR first; the getsentry PR is safe to deploy afterward.