### PR TITLE
build: run prisma migrate deploy as part of the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,21 @@ jobs:
     name: Lint and Build
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: changelog
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm prisma generate && next build",
+    "build": "pnpm prisma migrate deploy && pnpm prisma generate && next build",
     "start": "next start",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
Folds `prisma migrate deploy` into the single `pnpm build` script so every Vercel deploy applies pending migrations automatically — no more manual step like the one #111 required. CI gains a Postgres 16 service container so the same universal build runs end-to-end against a throwaway DB.

Verified locally: `pnpm build` against a fresh Postgres applies both migrations, generates the client, and builds Next cleanly.