### PR TITLE
Kotlin Multiplatform SDK Releases — June 2026

### DIFF
--- a/content/changelog/2026-06-kotlin-multiplatform-sdk-releases.md
+++ b/content/changelog/2026-06-kotlin-multiplatform-sdk-releases.md
@@ -1,0 +1,26 @@
+---
+title: Kotlin Multiplatform SDK Releases — June 2026
+slug: 2026-06-kotlin-multiplatform-sdk-releases
+summary: Added C++ exception monitoring option for Kotlin Multiplatform targets.
+categories:
+  - SDK
+platform:
+  - kotlin
+  - android
+broadcastCategory: sdk_update
+published: false
+date: 2026-06-30
+author: rahulchhabria@sentry.io
+---
+
+Releases covered: **0.27.0**
+
+| Version | Date | Link |
+|---------|------|------|
+| 0.27.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-kotlin-multiplatform/releases/tag/0.27.0) |
+
+## What changed
+
+- **C++ exception monitoring option (0.27.0):** Added `enableUnhandledCppExceptionMonitoring` to the SDK options. Note: on Apple/Compose Multiplatform targets it's recommended to disable this (`options.enableUnhandledCppExceptionMonitoring = false`) — unhandled Kotlin exceptions from CMP can otherwise be reported as generic `ExceptionObjHolderImpl` C++ crashes instead of useful Kotlin stack traces.
+
+_Tagged by @rahulchhabria_

--- a/content/changelog/2026-06-kotlin-multiplatform-sdk-releases.md
+++ b/content/changelog/2026-06-kotlin-multiplatform-sdk-releases.md
@@ -22,5 +22,3 @@ Releases covered: **0.27.0**
 ## What changed
 
 - **C++ exception monitoring option (0.27.0):** Added `enableUnhandledCppExceptionMonitoring` to the SDK options. Note: on Apple/Compose Multiplatform targets it's recommended to disable this (`options.enableUnhandledCppExceptionMonitoring = false`) — unhandled Kotlin exceptions from CMP can otherwise be reported as generic `ExceptionObjHolderImpl` C++ crashes instead of useful Kotlin stack traces.
-
-_Tagged by @rahulchhabria_


### PR DESCRIPTION
SDK release roundup for **sentry-kotlin-multiplatform** covering June 2026 (1 release: 0.27.0).

Platforms: `kotlin`, `android`

**Highlights:**
- New `enableUnhandledCppExceptionMonitoring` option. Note: recommended to **disable** on Apple/Compose Multiplatform targets to avoid Kotlin exceptions being misreported as generic C++ crashes.

cc @rahulchhabria

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->