### PR TITLE
Dart/Flutter SDK Releases — June 2026

### DIFF
--- a/content/changelog/2026-06-dart-sdk-releases.md
+++ b/content/changelog/2026-06-dart-sdk-releases.md
@@ -24,5 +24,3 @@ Releases covered: **9.22.0**
 - **Android replay trace ID sync (9.22.0):** Replay trace IDs are now synchronized on Android, enabling replay-by-trace lookup across platforms.
 - **Span v2 envelope metadata (9.22.0):** Added `ingest_settings` metadata to span v2 envelopes for improved server-side processing.
 - **Bug fix (9.22.0):** Fixed missing log byte outcomes that could cause incorrect data-discarded reporting.
-
-_Tagged by @rahulchhabria_

--- a/content/changelog/2026-06-dart-sdk-releases.md
+++ b/content/changelog/2026-06-dart-sdk-releases.md
@@ -1,0 +1,28 @@
+---
+title: Dart/Flutter SDK Releases — June 2026
+slug: 2026-06-dart-sdk-releases
+summary: Android replay trace ID sync, span v2 ingest metadata, and log byte outcome fixes.
+categories:
+  - SDK
+platform:
+  - dart
+  - flutter
+broadcastCategory: sdk_update
+published: false
+date: 2026-06-30
+author: rahulchhabria@sentry.io
+---
+
+Releases covered: **9.22.0**
+
+| Version | Date | Link |
+|---------|------|------|
+| 9.22.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-dart/releases/tag/9.22.0) |
+
+## What changed
+
+- **Android replay trace ID sync (9.22.0):** Replay trace IDs are now synchronized on Android, enabling replay-by-trace lookup across platforms.
+- **Span v2 envelope metadata (9.22.0):** Added `ingest_settings` metadata to span v2 envelopes for improved server-side processing.
+- **Bug fix (9.22.0):** Fixed missing log byte outcomes that could cause incorrect data-discarded reporting.
+
+_Tagged by @rahulchhabria_


### PR DESCRIPTION
SDK release roundup for **sentry-dart** covering June 2026 (1 release: 9.22.0).

Platforms: `dart`, `flutter`

**Highlights:**
- Android replay trace ID sync for cross-platform replay-by-trace lookup
- Span v2 envelope `ingest_settings` metadata
- Fixed missing log byte outcomes

cc @rahulchhabria

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->