### PR TITLE
PHP SDK Releases — June 2026

### DIFF
--- a/content/changelog/2026-06-php-sdk-releases.md
+++ b/content/changelog/2026-06-php-sdk-releases.md
@@ -25,5 +25,3 @@ Releases covered: **4.28.0 · 4.29.0**
 - **gen_ai span v2 protocol (4.29.0):** `gen_ai` spans are now sent using the span v2 protocol, aligning with other SDKs.
 - **Proxy-Authorization scrubbed by default (4.29.0):** `Proxy-Authorization` request headers are now scrubbed in addition to `Authorization`.
 - **Bug fixes (4.28.0 · 4.29.0):** Feature flag values now correctly serialize as a JSON list when a flag is updated multiple times; fatal error handler state is reset when starting a new runtime context.
-
-_Tagged by @rahulchhabria_

--- a/content/changelog/2026-06-php-sdk-releases.md
+++ b/content/changelog/2026-06-php-sdk-releases.md
@@ -1,0 +1,29 @@
+---
+title: PHP SDK Releases — June 2026
+slug: 2026-06-php-sdk-releases
+summary: SentryPropagator for OpenTelemetry, gen_ai span v2 protocol, and Proxy-Authorization header scrubbing by default.
+categories:
+  - SDK
+platform:
+  - php
+broadcastCategory: sdk_update
+published: false
+date: 2026-06-30
+author: rahulchhabria@sentry.io
+---
+
+Releases covered: **4.28.0 · 4.29.0**
+
+| Version | Date | Link |
+|---------|------|------|
+| 4.29.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-php/releases/tag/4.29.0) |
+| 4.28.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-php/releases/tag/4.28.0) |
+
+## What changed
+
+- **SentryPropagator for OpenTelemetry (4.28.0):** New `SentryPropagator` class to inject and extract `sentry-trace` headers in OpenTelemetry propagation contexts.
+- **gen_ai span v2 protocol (4.29.0):** `gen_ai` spans are now sent using the span v2 protocol, aligning with other SDKs.
+- **Proxy-Authorization scrubbed by default (4.29.0):** `Proxy-Authorization` request headers are now scrubbed in addition to `Authorization`.
+- **Bug fixes (4.28.0 · 4.29.0):** Feature flag values now correctly serialize as a JSON list when a flag is updated multiple times; fatal error handler state is reset when starting a new runtime context.
+
+_Tagged by @rahulchhabria_


### PR DESCRIPTION
SDK release roundup for **sentry-php** covering June 2026 (2 releases: 4.28.0 · 4.29.0).

Platforms: `php`

**Highlights:**
- New `SentryPropagator` for OpenTelemetry header injection/extraction
- `gen_ai` spans now use the span v2 protocol
- `Proxy-Authorization` headers scrubbed by default
- Fixed feature flag JSON serialization on multiple updates; fatal error handler state reset on new runtime context

cc @rahulchhabria

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->