### PR TITLE
Ruby SDK Releases — June 2026

### DIFF
--- a/content/changelog/2026-06-ruby-sdk-releases.md
+++ b/content/changelog/2026-06-ruby-sdk-releases.md
@@ -1,0 +1,31 @@
+---
+title: Ruby SDK Releases — June 2026
+slug: 2026-06-ruby-sdk-releases
+summary: New sentry-yabeda gem for Metrics, Kamal release detection, Sidekiq retry limit fix, and stacktrace payload leak fix.
+categories:
+  - SDK
+platform:
+  - ruby
+broadcastCategory: sdk_update
+published: false
+date: 2026-06-30
+author: rahulchhabria@sentry.io
+---
+
+Releases covered: **6.6.0 · 6.6.1 · 6.6.2**
+
+| Version | Date | Link |
+|---------|------|------|
+| 6.6.2 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-ruby/releases/tag/6.6.2) |
+| 6.6.1 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-ruby/releases/tag/6.6.1) |
+| 6.6.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-ruby/releases/tag/6.6.0) |
+
+## What changed
+
+- **New `sentry-yabeda` gem (6.6.0):** Integrates Sentry Metrics with [Yabeda](https://github.com/yabeda-rb/yabeda) — add `gem "sentry-yabeda"` to your Gemfile; it registers automatically on require, no extra setup needed.
+- **Kamal release detection (6.6.0):** The SDK now auto-detects the release version from Kamal deployments.
+- **Sidekiq fix (6.6.0):** Errors are now correctly reported when the Sidekiq retry limit is set below the attempt threshold.
+- **Stacktrace fix (6.6.0):** Stopped leaking internal frame state into the event payload.
+- **Concurrency fix (6.6.1):** `TelemetryEventBuffer` is now guarded against re-entrant mutex acquisition.
+
+_Tagged by @rahulchhabria_

--- a/content/changelog/2026-06-ruby-sdk-releases.md
+++ b/content/changelog/2026-06-ruby-sdk-releases.md
@@ -27,5 +27,3 @@ Releases covered: **6.6.0 · 6.6.1 · 6.6.2**
 - **Sidekiq fix (6.6.0):** Errors are now correctly reported when the Sidekiq retry limit is set below the attempt threshold.
 - **Stacktrace fix (6.6.0):** Stopped leaking internal frame state into the event payload.
 - **Concurrency fix (6.6.1):** `TelemetryEventBuffer` is now guarded against re-entrant mutex acquisition.
-
-_Tagged by @rahulchhabria_


### PR DESCRIPTION
SDK release roundup for **sentry-ruby** covering June 2026 (3 releases: 6.6.0 · 6.6.1 · 6.6.2).

Platforms: `ruby`

**Highlights:**
- New `sentry-yabeda` gem: integrates Sentry Metrics with Yabeda — add to Gemfile, registers automatically
- Kamal release auto-detection
- Sidekiq: report errors when retry limit is below attempt threshold
- Fixed internal frame state leaking into event payload
- `TelemetryEventBuffer` guarded against re-entrant mutex acquisition

cc @rahulchhabria

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->