### PR TITLE
JavaScript SDK Releases — June 2026 (detailed)

### DIFF
--- a/content/changelog/2026-06-javascript-sdk-releases.md
+++ b/content/changelog/2026-06-javascript-sdk-releases.md
@@ -28,10 +28,10 @@ Releases covered:
 
 ## TL;DR
 
-- `streamGenAiSpans` is now enabled by default — `gen_ai` spans stream as v2 envelope items, preventing drops and disabling default message truncation; self-hosted users can opt out with `streamGenAiSpans: false`.
+- `streamGenAiSpans` is now enabled by default — `gen_ai` spans are sent as v2 envelope items, preventing size limit drops and disabling default message truncation; self-hosted users can opt out with `streamGenAiSpans: false`.
 - Expanded Cloudflare instrumentation: R2 buckets, D1 batch/exec/withSession, SQLite Durable Objects SQL API, and sync KV are all now auto-instrumented.
-- `vercelAiIntegration` adds Vercel AI SDK v7 support; AWS SDK clients ≥ 3.1046.0 are auto-instrumented; Bun and Deno get orchestrion runtime hooks.
-- New top-level `Sentry.setAttribute(s)` APIs; Hono transactions named after matched route handlers; `bindScopeToEmitter` for event-emitter-scoped traces.
+- `vercelAiIntegration` adds Vercel AI SDK v7 support
+- New top-level `Sentry.setAttribute(s)` APIs; Hono transactions named after matched route handlers
 - React Router v6/v7 navigation tracing fix; PostgresJS duplicate span fix; Next.js redirect classification fix.
 
 ## Release notes
@@ -42,9 +42,9 @@ Releases covered:
 
 Cloudflare storage instrumentation expanded across four releases: 10.60.0 added R2 bucket auto-instrumentation, 10.61.0 added D1 batch operations, `exec()`, and `withSession()`, as well as SQL API instrumentation for SQLite Durable Objects. 10.59.0 added synchronous KV instrumentation. Together these give complete zero-config coverage for Cloudflare storage primitives.
 
-10.62.0 extends `vercelAiIntegration` to support v7 of the Vercel AI SDK (note: not yet available on Cloudflare Workers). In 10.59.0, AWS SDK clients at v3.1046.0 or later are automatically instrumented. Bun gained an orchestrion build plugin in 10.59.0 and Deno a runtime hook, enabling zero-config instrumentation for those runtimes.
+10.62.0 extends `vercelAiIntegration` to support v7 of the Vercel AI SDK (note: not yet available on Cloudflare Workers).
 
-10.61.0 adds two new top-level APIs — `Sentry.setAttribute(key, value)` and `Sentry.setAttributes(attributes)` — for setting custom attributes on the currently active span without a direct span reference. Hono transactions are now named after the matched route handler. 10.60.0 introduces `bindScopeToEmitter(emitter)`, which propagates the active Sentry scope to all listeners of a Node.js `EventEmitter`.
+10.61.0 adds two new top-level APIs — `Sentry.setAttribute(key, value)` and `Sentry.setAttributes(attributes)` — for setting custom attributes on the currently active span without a direct span reference. Hono transactions are now named after the matched route handler.
 
 ### Bug Fixes
 

--- a/content/changelog/2026-06-javascript-sdk-releases.md
+++ b/content/changelog/2026-06-javascript-sdk-releases.md
@@ -40,7 +40,7 @@ Releases covered:
 
 10.61.0 enables `streamGenAiSpans` by default. `gen_ai` spans are extracted from transactions and sent as v2 envelope items, which means they can no longer be dropped when the transaction payload exceeds size limits, and AI message data is no longer truncated by default. Pass `enableTruncation: true` on the respective AI integration to re-enable truncation. Self-hosted Sentry users should set `streamGenAiSpans: false` until their instance supports streamed spans.
 
-Cloudflare storage instrumentation expanded across four releases: 10.60.0 added R2 bucket auto-instrumentation, 10.61.0 added D1 batch operations, `exec()`, and `withSession()`, as well as SQL API instrumentation for SQLite Durable Objects. 10.59.0 added synchronous KV instrumentation. Together these give complete zero-config coverage for Cloudflare storage primitives.
+Cloudflare storage instrumentation expanded across three releases: 10.60.0 added R2 bucket auto-instrumentation, 10.61.0 added D1 batch operations, `exec()`, and `withSession()`, as well as SQL API instrumentation for SQLite Durable Objects. 10.59.0 added synchronous KV instrumentation. Together these give complete zero-config coverage for Cloudflare storage primitives.
 
 10.62.0 extends `vercelAiIntegration` to support v7 of the Vercel AI SDK (note: not yet available on Cloudflare Workers).
 

--- a/content/changelog/2026-06-javascript-sdk-releases.md
+++ b/content/changelog/2026-06-javascript-sdk-releases.md
@@ -56,4 +56,4 @@ In 10.58.0, Next.js server actions that perform redirects were incorrectly class
 
 10.56.0 fixes `instrumentDurableObjectWithSentry` accidentally breaking Cloudflare Agents when applied to Durable Objects that use the Agents SDK.
 
-10.62.0 makes the SDK resilient to runtimes where `tracingChannel` is not available (Node < 22), instead of throwing at runtime.
+10.62.0 makes the SDK resilient to runtimes where `tracingChannel` is not available (older Node 18 releases before 18.19.0, and other runtimes lacking the API), instead of throwing at runtime.

--- a/content/changelog/2026-06-javascript-sdk-releases.md
+++ b/content/changelog/2026-06-javascript-sdk-releases.md
@@ -14,22 +14,46 @@ date: 2026-06-30
 author: rahulchhabria@sentry.io
 ---
 
-Releases covered: **10.56.0 · 10.57.0 · 10.58.0 · 10.59.0 · 10.60.0 · 10.61.0 · 10.62.0**
+Releases covered:
 
 | Version | Date | Link |
 |---------|------|------|
-| 10.62.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.62.0) |
-| 10.61.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.61.0) |
-| 10.60.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.60.0) |
-| 10.59.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.59.0) |
-| 10.58.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.58.0) |
-| 10.57.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.57.0) |
-| 10.56.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.56.0) |
+| 10.62.0 | 2026-06-26 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.62.0) |
+| 10.61.0 | 2026-06-25 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.61.0) |
+| 10.60.0 | 2026-06-23 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.60.0) |
+| 10.59.0 | 2026-06-19 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.59.0) |
+| 10.58.0 | 2026-06-15 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.58.0) |
+| 10.57.0 | 2026-06-09 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.57.0) |
+| 10.56.0 | 2026-06-02 | [Release notes](https://github.com/getsentry/sentry-javascript/releases/tag/10.56.0) |
 
-## What changed
+## TL;DR
 
-- **gen_ai span streaming on by default (10.61.0):** `streamGenAiSpans` is now enabled by default — `gen_ai` spans stream as v2 envelope items, preventing drops and disabling default message truncation. Self-hosted users can opt out with `streamGenAiSpans: false`.
-- **Expanded Cloudflare instrumentation (10.60.0 · 10.61.0):** R2 buckets, D1 batch/exec/withSession, SQLite Durable Objects SQL API, and sync KV are all now auto-instrumented.
-- **New integrations & runtime support (10.59.0 · 10.62.0):** `vercelAiIntegration` adds Vercel AI SDK v7 support; AWS SDK clients ≥ 3.1046.0 are auto-instrumented; Bun and Deno get orchestrion runtime hooks.
-- **New APIs (10.61.0):** Top-level `Sentry.setAttribute(s)` APIs added; Hono transactions now named after matched route handlers; `bindScopeToEmitter` added for event-emitter-scoped traces.
-- **Bug fixes (10.57.0 · 10.58.0):** React Router v6/v7 navigation detection moved to layout effect for correct trace propagation; PostgresJS no longer emits duplicate spans per query; Next.js redirects no longer reported as `internal_error`.
+- `streamGenAiSpans` is now enabled by default — `gen_ai` spans stream as v2 envelope items, preventing drops and disabling default message truncation; self-hosted users can opt out with `streamGenAiSpans: false`.
+- Expanded Cloudflare instrumentation: R2 buckets, D1 batch/exec/withSession, SQLite Durable Objects SQL API, and sync KV are all now auto-instrumented.
+- `vercelAiIntegration` adds Vercel AI SDK v7 support; AWS SDK clients ≥ 3.1046.0 are auto-instrumented; Bun and Deno get orchestrion runtime hooks.
+- New top-level `Sentry.setAttribute(s)` APIs; Hono transactions named after matched route handlers; `bindScopeToEmitter` for event-emitter-scoped traces.
+- React Router v6/v7 navigation tracing fix; PostgresJS duplicate span fix; Next.js redirect classification fix.
+
+## Release notes
+
+### New Features
+
+10.61.0 enables `streamGenAiSpans` by default. `gen_ai` spans are extracted from transactions and sent as v2 envelope items, which means they can no longer be dropped when the transaction payload exceeds size limits, and AI message data is no longer truncated by default. Pass `enableTruncation: true` on the respective AI integration to re-enable truncation. Self-hosted Sentry users should set `streamGenAiSpans: false` until their instance supports streamed spans.
+
+Cloudflare storage instrumentation expanded across four releases: 10.60.0 added R2 bucket auto-instrumentation, 10.61.0 added D1 batch operations, `exec()`, and `withSession()`, as well as SQL API instrumentation for SQLite Durable Objects. 10.59.0 added synchronous KV instrumentation. Together these give complete zero-config coverage for Cloudflare storage primitives.
+
+10.62.0 extends `vercelAiIntegration` to support v7 of the Vercel AI SDK (note: not yet available on Cloudflare Workers). In 10.59.0, AWS SDK clients at v3.1046.0 or later are automatically instrumented. Bun gained an orchestrion build plugin in 10.59.0 and Deno a runtime hook, enabling zero-config instrumentation for those runtimes.
+
+10.61.0 adds two new top-level APIs — `Sentry.setAttribute(key, value)` and `Sentry.setAttributes(attributes)` — for setting custom attributes on the currently active span without a direct span reference. Hono transactions are now named after the matched route handler. 10.60.0 introduces `bindScopeToEmitter(emitter)`, which propagates the active Sentry scope to all listeners of a Node.js `EventEmitter`.
+
+### Bug Fixes
+
+10.57.0 moves React Router v6/v7 navigation detection from a regular effect to a layout effect. This ensures the correct parent trace is present when the navigation span is created, closing trace propagation gaps visible in distributed traces.
+
+Also in 10.57.0, the PostgresJS integration was emitting a duplicate span for every query due to a listener registration bug. Only one span is now created per query.
+
+In 10.58.0, Next.js server actions that perform redirects were incorrectly classified as `internal_error`. They are now reported as `ok`.
+
+10.56.0 fixes `instrumentDurableObjectWithSentry` accidentally breaking Cloudflare Agents when applied to Durable Objects that use the Agents SDK.
+
+10.62.0 makes the SDK resilient to runtimes where `tracingChannel` is not available (Node < 22), instead of throwing at runtime.


### PR DESCRIPTION
Builds on #124 with three improvements:

- **Table dates**: each release now shows its actual publish date
- **TL;DR**: `## What changed` → `## TL;DR`
- **Prose release notes**: new section structured by craft changelog ordering (New Features → Bug Fixes; Internal omitted), synthesising all 7 releases in readable paragraphs

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->