### PR TITLE
Kotlin Multiplatform SDK Releases — June 2026 (detailed)

### DIFF
--- a/content/changelog/2026-06-kotlin-multiplatform-sdk-releases.md
+++ b/content/changelog/2026-06-kotlin-multiplatform-sdk-releases.md
@@ -1,7 +1,7 @@
 ---
 title: Kotlin Multiplatform SDK Releases — June 2026
 slug: 2026-06-kotlin-multiplatform-sdk-releases
-summary: Added C++ exception monitoring option for Kotlin Multiplatform targets.
+summary: Added C++ exception monitoring option with a caveat for Compose Multiplatform targets.
 categories:
   - SDK
 platform:
@@ -13,12 +13,18 @@ date: 2026-06-30
 author: rahulchhabria@sentry.io
 ---
 
-Releases covered: **0.27.0**
+Releases covered:
 
 | Version | Date | Link |
 |---------|------|------|
-| 0.27.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-kotlin-multiplatform/releases/tag/0.27.0) |
+| 0.27.0 | 2026-06-03 | [Release notes](https://github.com/getsentry/sentry-kotlin-multiplatform/releases/tag/0.27.0) |
 
-## What changed
+## TL;DR
 
-- **C++ exception monitoring option (0.27.0):** Added `enableUnhandledCppExceptionMonitoring` to the SDK options. Note: on Apple/Compose Multiplatform targets it's recommended to disable this (`options.enableUnhandledCppExceptionMonitoring = false`) — unhandled Kotlin exceptions from CMP can otherwise be reported as generic `ExceptionObjHolderImpl` C++ crashes instead of useful Kotlin stack traces.
+- New `enableUnhandledCppExceptionMonitoring` option — on Apple/Compose Multiplatform targets it is strongly recommended to disable it to avoid Kotlin exceptions being misreported as generic C++ crashes.
+
+## Release notes
+
+### New Features
+
+0.27.0 adds an `enableUnhandledCppExceptionMonitoring` option that mirrors the same option available in the Cocoa SDK. When enabled, the native crash handler also watches for unhandled C++ exceptions. On Apple targets used with Compose Multiplatform, disabling this option (`options.enableUnhandledCppExceptionMonitoring = false`) is strongly recommended: Kotlin exceptions from CMP can propagate as C++ exceptions at the native boundary, and with the monitor active they may appear in Sentry as generic `ExceptionObjHolderImpl` crashes rather than readable Kotlin stack traces.


### PR DESCRIPTION
Builds on #127 with three improvements:

- **Table dates**: each release now shows its actual publish date
- **TL;DR**: `## What changed` → `## TL;DR`
- **Prose release notes**: new New Features prose section for 0.27.0

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->