### PR TITLE
Dart/Flutter SDK Releases — June 2026 (detailed)

### DIFF
--- a/content/changelog/2026-06-dart-sdk-releases.md
+++ b/content/changelog/2026-06-dart-sdk-releases.md
@@ -1,7 +1,7 @@
 ---
 title: Dart/Flutter SDK Releases — June 2026
 slug: 2026-06-dart-sdk-releases
-summary: Android replay trace ID sync, span v2 ingest metadata, and log byte outcome fixes.
+summary: Android replay trace ID sync, span v2 ingest metadata, and log byte outcome fix.
 categories:
   - SDK
 platform:
@@ -13,14 +13,24 @@ date: 2026-06-30
 author: rahulchhabria@sentry.io
 ---
 
-Releases covered: **9.22.0**
+Releases covered:
 
 | Version | Date | Link |
 |---------|------|------|
-| 9.22.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-dart/releases/tag/9.22.0) |
+| 9.22.0 | 2026-06-11 | [Release notes](https://github.com/getsentry/sentry-dart/releases/tag/9.22.0) |
 
-## What changed
+## TL;DR
 
-- **Android replay trace ID sync (9.22.0):** Replay trace IDs are now synchronized on Android, enabling replay-by-trace lookup across platforms.
-- **Span v2 envelope metadata (9.22.0):** Added `ingest_settings` metadata to span v2 envelopes for improved server-side processing.
-- **Bug fix (9.22.0):** Fixed missing log byte outcomes that could cause incorrect data-discarded reporting.
+- Android replay trace IDs are now synchronised with the native SDK, enabling replay-by-trace lookup across platforms.
+- Span v2 envelopes now carry `ingest_settings` metadata for improved server-side processing.
+- Fixed missing log byte outcomes that could cause inaccurate data-loss figures on the Sentry Stats page.
+
+## Release notes
+
+### New Features
+
+9.22.0 synchronises replay trace IDs with the native Android SDK on the Flutter/Android layer, so replays captured on Android are correctly associated with traces that originate in Dart. The release also adds `ingest_settings` metadata to span v2 envelopes, which the Sentry ingest pipeline uses for more efficient span routing and processing. Replay IDs are additionally attached to span telemetry.
+
+### Bug Fixes
+
+9.22.0 fixes log byte outcomes not being emitted correctly. These outcomes are how the SDK reports to Sentry the number of log bytes it discarded; incorrect values would have caused inaccurate figures on the Sentry Stats page.


### PR DESCRIPTION
Builds on #128 with three improvements:

- **Table dates**: each release now shows its actual publish date
- **TL;DR**: `## What changed` → `## TL;DR`
- **Prose release notes**: new New Features and Bug Fixes prose sections for 9.22.0

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->