### PR TITLE
PHP SDK Releases — June 2026 (detailed)

### DIFF
--- a/content/changelog/2026-06-php-sdk-releases.md
+++ b/content/changelog/2026-06-php-sdk-releases.md
@@ -12,16 +12,30 @@ date: 2026-06-30
 author: rahulchhabria@sentry.io
 ---
 
-Releases covered: **4.28.0 · 4.29.0**
+Releases covered:
 
 | Version | Date | Link |
 |---------|------|------|
-| 4.29.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-php/releases/tag/4.29.0) |
-| 4.28.0 | Jun 2026 | [Release notes](https://github.com/getsentry/sentry-php/releases/tag/4.28.0) |
+| 4.29.0 | 2026-06-29 | [Release notes](https://github.com/getsentry/sentry-php/releases/tag/4.29.0) |
+| 4.28.0 | 2026-06-11 | [Release notes](https://github.com/getsentry/sentry-php/releases/tag/4.28.0) |
 
-## What changed
+## TL;DR
 
-- **SentryPropagator for OpenTelemetry (4.28.0):** New `SentryPropagator` class to inject and extract `sentry-trace` headers in OpenTelemetry propagation contexts.
-- **gen_ai span v2 protocol (4.29.0):** `gen_ai` spans are now sent using the span v2 protocol, aligning with other SDKs.
-- **Proxy-Authorization scrubbed by default (4.29.0):** `Proxy-Authorization` request headers are now scrubbed in addition to `Authorization`.
-- **Bug fixes (4.28.0 · 4.29.0):** Feature flag values now correctly serialize as a JSON list when a flag is updated multiple times; fatal error handler state is reset when starting a new runtime context.
+- New `SentryPropagator` for OpenTelemetry header injection/extraction.
+- `gen_ai` spans now use the span v2 protocol.
+- `Proxy-Authorization` request headers scrubbed by default.
+- Fixed feature flag JSON serialization on multiple updates; fatal error handler state reset on new runtime context.
+
+## Release notes
+
+### New Features
+
+4.28.0 adds a `SentryPropagator` class implementing the OpenTelemetry `TextMapPropagatorInterface`. It injects and extracts the `sentry-trace` header in OTel propagation contexts, making it straightforward to use Sentry distributed tracing in OpenTelemetry-instrumented PHP applications.
+
+4.29.0 sends `gen_ai` spans using the span v2 protocol, aligning PHP with the behaviour already shipping in Python and JavaScript. The same release scrubs `Proxy-Authorization` request headers by default, alongside the existing `Authorization` scrubbing.
+
+### Bug Fixes
+
+4.28.0 fixes a bug where updating a feature flag value more than once within a single request corrupted the serialised flag list. The SDK now correctly preserves the list as a JSON array across multiple updates.
+
+4.29.0 fixes the fatal error handler's state not being reset when a new runtime context was started — for example in long-lived workers using Swoole or similar frameworks. This could cause the handler to behave incorrectly across request boundaries.


### PR DESCRIPTION
Builds on #134 with three improvements:

- **Table dates**: each release now shows its actual publish date
- **TL;DR**: `## What changed` → `## TL;DR`
- **Prose release notes**: new New Features and Bug Fixes prose sections for 4.28.0 and 4.29.0

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B7SMN7ZHD%3A1783219862.223729/?project=4510944073809921)

<!-- junior-session-footer:end -->