### PR TITLE
fix: preselect only the post's own categories when editing

### DIFF
--- a/src/client/components/forms/editChangelogForm.tsx
+++ b/src/client/components/forms/editChangelogForm.tsx
@@ -26,7 +26,7 @@ export const EditChangelogForm = ({
   changelog,
   categories,
 }: {
-  changelog: Changelog;
+  changelog: Changelog & { categories: Category[] };
   categories: Category[];
 }) => {
   const [_state, formAction] = useActionState(editChangelog, {});
@@ -55,7 +55,7 @@ export const EditChangelogForm = ({
           className="mt-1 mb-6"
           label="Category"
           placeholder="Select Category"
-          defaultValue={categories.map((category) => ({
+          defaultValue={changelog.categories.map((category) => ({
             label: category.name,
             value: category.name,
           }))}


### PR DESCRIPTION
## Problem

Opening any changelog post in the editor auto-selected **every** category. Saving the post then tagged it with all categories.

The category picker in `editChangelogForm.tsx` used the full list of available categories (the `categories` prop) as its `defaultValue`. That prop is meant to populate the selectable `options`, not the pre-selected values. The edit page already fetches the post's own assigned categories and passes them as `changelog.categories`, but the form ignored that data.

## Fix

- Point the category `Select`'s `defaultValue` at `changelog.categories` (the post's actual assigned categories) while keeping the full list as `options`.
- Extend the form's `changelog` prop type to `Changelog & { categories: Category[] }` to reflect what the edit page already passes.

The create form was already correct (no `defaultValue`), so no change there.

## Verification

- `tsc --noEmit` — clean for the changed file (only a pre-existing, unrelated `squiggle.png` image-import error remains)
- Biome lint — clean
- Pre-commit hooks passed

Not exercised end-to-end (the editor needs Contentful/Postgres/auth env to run locally).

https://claude.ai/code/session_01BmAz5ZJEAsxqyYLaTnf38j

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmAz5ZJEAsxqyYLaTnf38j)_