### PR TITLE
fix(changelog): resolve index-page hydration mismatch (Seer root-cause triage of open Sentry issues)

### DIFF
--- a/src/app/changelog/feedSkeleton.tsx
+++ b/src/app/changelog/feedSkeleton.tsx
@@ -1,0 +1,40 @@
+import { LoadingArticle } from "@/client/components/article";
+
+// Shared skeleton for the changelog feed. Used both by the route-level
+// loading.tsx and as the <Suspense> fallback on the index page so the
+// static shell can be prerendered while the dynamic feed streams in.
+export function FeedSkeleton() {
+  return (
+    <main className="w-full bg-darkPurple min-h-screen">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6">
+        <div className="sm:flex sm:gap-10">
+          {/* Feed skeleton */}
+          <div className="flex-1 min-w-0 pt-6 pb-10">
+            {/* Month divider skeleton */}
+            <div className="flex items-center gap-3 mt-2 mb-4">
+              <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
+              <div className="flex-1 h-px bg-white/10" />
+            </div>
+            <LoadingArticle />
+            <LoadingArticle />
+            <LoadingArticle />
+          </div>
+
+          {/* Sidebar skeleton — desktop only */}
+          <div className="hidden sm:block w-40 flex-shrink-0">
+            <div className="pt-6">
+              <div className="h-8 bg-white/10 animate-pulse rounded-lg w-full mb-6" />
+              <div className="h-3 bg-white/10 animate-pulse rounded w-14 mb-3" />
+              <div className="flex flex-col gap-2">
+                <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
+                <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
+                <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
+                <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/changelog/loading.tsx
+++ b/src/app/changelog/loading.tsx
@@ -1,43 +1,12 @@
 import { Fragment } from "react";
-
-import { LoadingArticle } from "@/client/components/article";
+import { FeedSkeleton } from "./feedSkeleton";
 import Header from "./header";
 
 export default function Loading() {
   return (
     <Fragment>
       <Header loading />
-      <main className="w-full bg-darkPurple min-h-screen">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6">
-          <div className="sm:flex sm:gap-10">
-            {/* Feed skeleton */}
-            <div className="flex-1 min-w-0 pt-6 pb-10">
-              {/* Month divider skeleton */}
-              <div className="flex items-center gap-3 mt-2 mb-4">
-                <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
-                <div className="flex-1 h-px bg-white/10" />
-              </div>
-              <LoadingArticle />
-              <LoadingArticle />
-              <LoadingArticle />
-            </div>
-
-            {/* Sidebar skeleton — desktop only */}
-            <div className="hidden sm:block w-40 flex-shrink-0">
-              <div className="pt-6">
-                <div className="h-8 bg-white/10 animate-pulse rounded-lg w-full mb-6" />
-                <div className="h-3 bg-white/10 animate-pulse rounded w-14 mb-3" />
-                <div className="flex flex-col gap-2">
-                  <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
-                  <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
-                  <div className="h-3 bg-white/10 animate-pulse rounded w-24" />
-                  <div className="h-3 bg-white/10 animate-pulse rounded w-20" />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </main>
+      <FeedSkeleton />
     </Fragment>
   );
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,20 +1,33 @@
 import type { Metadata } from "next";
 import { connection } from "next/server";
-import { Fragment } from "react";
+import { Fragment, Suspense } from "react";
 import { ChangelogList } from "@/client/components/list";
 import { getChangelogSummaries } from "../../server/utils";
+import { FeedSkeleton } from "./feedSkeleton";
 import Header from "./header";
 
-export default async function Page() {
-  await connection();
-  const changelogs = await getChangelogSummaries();
-
+export default function Page() {
+  // Keep the header + document metadata in a statically-prerenderable shell and
+  // stream the dynamic, search-param-driven feed inside an explicit Suspense
+  // boundary. Reading URL state (via nuqs/useSearchParams in <ChangelogList />)
+  // outside of a Suspense boundary makes the prerendered tree disagree with the
+  // client resume under `cacheComponents`, which surfaced as a hydration
+  // mismatch ("Cannot read properties of null (reading 'parentNode')").
   return (
     <Fragment>
       <Header />
-      <ChangelogList changelogs={changelogs} />
+      <Suspense fallback={<FeedSkeleton />}>
+        <ChangelogFeed />
+      </Suspense>
     </Fragment>
   );
+}
+
+async function ChangelogFeed() {
+  await connection();
+  const changelogs = await getChangelogSummaries();
+
+  return <ChangelogList changelogs={changelogs} />;
 }
 
 export function generateMetadata(): Metadata {


### PR DESCRIPTION
## Summary

Pulled all **17 open (unresolved) issues** from the Sentry `changelog` project (org `sentry`) and ran **Seer root-cause analysis** on each. This PR contains the one change that is a genuine, fixable application bug; the remaining issues are triaged directly in Sentry (see table) because their root causes are outside this codebase (bot/scanner traffic, third-party browser-injected scripts, a separate cloud function, deployment version skew, or infra/config).

## Code change — CHANGELOG-7X (hydration mismatch on `/changelog`)

**Seer root cause:** The index page awaited dynamic data at the page top level, so the search-param-driven client feed (`ChangelogList`, which reads URL state via `nuqs`/`useSearchParams`) rendered outside any explicit `Suspense` boundary. Under `cacheComponents: true`, the statically prerendered tree then disagreed with the client resume, surfacing as `TypeError: Cannot read properties of null (reading 'parentNode')` in React's streaming reconciliation.

**Fix:** Keep the header + document metadata in a statically-prerenderable shell and stream the dynamic feed inside an explicit `<Suspense>` boundary — the idiomatic Cache Components pattern.

- `src/app/changelog/page.tsx` — static shell + `<Suspense>`-wrapped `<ChangelogFeed>`
- `src/app/changelog/feedSkeleton.tsx` — extracted shared feed skeleton (new)
- `src/app/changelog/loading.tsx` — reuse the shared skeleton (DRY)

**Verification:** `biome check` clean, `tsc --noEmit` clean (only the pre-existing `squiggle.png` image-type note, unrelated), `vitest run` 25/25 passing. Full hydration confirmation requires a production deploy (hydration can't be reproduced in unit tests).

## Not fixed here — framework-level (needs upstream Next.js)

**CHANGELOG-1 / CHANGELOG-8B** — `__next_metadata_boundary__` resume mismatch on `/changelog/[slug]`. Seer attributes this to a **Next.js 16.2.6 + Turbopack async-metadata-streaming** interaction (100% of events on Turbopack). The `[slug]` route is already `Suspense`-wrapped via `loading.tsx`, so there is no safe app-level structural fix — this should be tracked against a Next.js upgrade rather than patched speculatively. Left open in Sentry.

## Triaged in Sentry (not app-code bugs)

| Issue | Root cause (Seer) | Action |
|---|---|---|
| CHANGELOG-82 | `CONFIG`/`updateGapFiller` — injected marketing-shell script, not in repo | ignore |
| CHANGELOG-73 | Brave/iOS injects `window.__firefox__` script | ignore |
| CHANGELOG-7W | ProductFruits third-party fetch blocked | ignore |
| CHANGELOG-9 | Browser extension mutates DOM after RSC re-render | ignore |
| CHANGELOG-48 | Stale `Next-Router-State-Tree` across deploys (framework) | ignore |
| CHANGELOG-7Z / 3T / 7Y / 85 | "Failed to find Server Action" — bot POSTs / stale action IDs across deploys | ignore |
| CHANGELOG-3W | Scanner-injected `_rsc` param → FormData parse | ignore |
| CHANGELOG-7J | Twitter API 402 CreditsDepleted (separate `changelog-twitter-poster` cloud fn) | ignore |
| CHANGELOG-8C | ReadTimeout fetching feed.xml (same external cloud fn) | ignore |
| CHANGELOG-84 | DB endpoint unreachable from serverless runtime (infra) | ignore |
| CHANGELOG-8D | Preview deploy missing `NEXTAUTH_SECRET` (config) | ignore |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjXWBRZkUCE3W9kXrcyYih)_