### PR TITLE
Add Seer GitLab support changelog entry

### DIFF
--- a/content/changelog/2026-07-seer-supports-gitlab.md
+++ b/content/changelog/2026-07-seer-supports-gitlab.md
@@ -1,0 +1,20 @@
+---
+title: Seer now supports GitLab
+slug: seer-supports-gitlab
+summary: Seer can now use your GitLab code files in Root Cause Analysis and open Merge Requests with a proposed fix — now generally available.
+categories:
+  - AI
+  - Integrations
+broadcastCategory: feature
+published: true
+date: 2026-07-21
+---
+
+Seer, Sentry's AI debugging agent, now works with GitLab — and it's generally available to everyone.
+
+When Seer investigates an issue, it can now use your GitLab code files as part of its Root Cause Analysis, giving it the context it needs to understand the code behind an error and trace it back to the source. Once Seer identifies a fix, it can open a new Merge Request directly from that analysis — taking you from error to proposed fix without leaving your workflow.
+
+## What's new
+
+- **Root Cause Analysis with GitLab context** — Seer reads the relevant files from your GitLab repositories to pinpoint what went wrong.
+- **Merge Requests from RCA** — Turn a root cause into action. Seer can create a new Merge Request with a proposed fix straight from its analysis.

--- a/content/changelog/2026-07-seer-supports-gitlab.md
+++ b/content/changelog/2026-07-seer-supports-gitlab.md
@@ -2,7 +2,6 @@
 title: Seer now supports GitLab
 slug: seer-supports-gitlab
 summary: Seer can now use your GitLab code files in Root Cause Analysis and open Merge Requests with a proposed fix — now generally available.
-image: /img/hero.png
 categories:
   - AI
   - Integrations

--- a/content/changelog/2026-07-seer-supports-gitlab.md
+++ b/content/changelog/2026-07-seer-supports-gitlab.md
@@ -2,6 +2,7 @@
 title: Seer now supports GitLab
 slug: seer-supports-gitlab
 summary: Seer can now use your GitLab code files in Root Cause Analysis and open Merge Requests with a proposed fix — now generally available.
+image: /img/hero.png
 categories:
   - AI
   - Integrations
@@ -18,3 +19,5 @@ When Seer investigates an issue, it can now use your GitLab code files as part o
 
 - **Root Cause Analysis with GitLab context** — Seer reads the relevant files from your GitLab repositories to pinpoint what went wrong.
 - **Merge Requests from RCA** — Turn a root cause into action. Seer can create a new Merge Request with a proposed fix straight from its analysis.
+
+![Seer creating a GitLab merge request](https://cslswue7zohm4cat.public.blob.vercel-storage.com/gitlab-merge-request.webp)

--- a/scripts/changelog/sync.ts
+++ b/scripts/changelog/sync.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { config } from "dotenv";
 import { eq, inArray, sql } from "drizzle-orm";
 import { drizzle, type NodePgTransaction } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
@@ -11,10 +10,6 @@ import {
 } from "../../src/server/db/schema";
 import { loadChangelogFiles, resolveDate, validateEntries } from "./lib.mjs";
 
-// Load the Neon dev-branch URL from .env.development.local locally; no-op in CI.
-config({ path: ".env.development.local" });
-config({ path: ".env.local" });
-
 const schema = {
   Category,
   Changelog,
@@ -24,12 +19,7 @@ const schema = {
 
 const pool = new Pool({
   connectionString: process.env.NEON_DATABASE_URL,
-});
-
-// Neon pooled connections reject startup `options` like statement_timeout.
-// Set it after connect instead (works with both pooled and unpooled URLs).
-pool.on("connect", (client) => {
-  client.query("SET statement_timeout = 60000");
+  options: "-c statement_timeout=60000",
 });
 
 const db = drizzle(pool, { schema });

--- a/scripts/changelog/sync.ts
+++ b/scripts/changelog/sync.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { config } from "dotenv";
 import { eq, inArray, sql } from "drizzle-orm";
 import { drizzle, type NodePgTransaction } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
@@ -10,6 +11,10 @@ import {
 } from "../../src/server/db/schema";
 import { loadChangelogFiles, resolveDate, validateEntries } from "./lib.mjs";
 
+// Load the Neon dev-branch URL from .env.development.local locally; no-op in CI.
+config({ path: ".env.development.local" });
+config({ path: ".env.local" });
+
 const schema = {
   Category,
   Changelog,
@@ -19,7 +24,12 @@ const schema = {
 
 const pool = new Pool({
   connectionString: process.env.NEON_DATABASE_URL,
-  options: "-c statement_timeout=60000",
+});
+
+// Neon pooled connections reject startup `options` like statement_timeout.
+// Set it after connect instead (works with both pooled and unpooled URLs).
+pool.on("connect", (client) => {
+  client.query("SET statement_timeout = 60000");
 });
 
 const db = drizzle(pool, { schema });


### PR DESCRIPTION
## Summary
- Adds a published changelog entry for Seer GitLab support (RCA context + merge requests from analysis), with an inline WebP screenshot.

## Test plan
- [ ] Preview the entry at `/changelog/seer-supports-gitlab/`
- [ ] Confirm the default hero (`/img/hero.png`) and the inline WebP screenshot render
- [ ] Run `pnpm changelog:validate`