### PR TITLE
chore: sync header.json from static-sites

### DIFF
--- a/src/lib/navigation/header.json
+++ b/src/lib/navigation/header.json
@@ -177,7 +177,7 @@
                         "destination": "https://sentry.io/integrations/github/",
                         "variant": "default",
                         "icon": {
-                          "url": "/astro-assets/nav-icons/github.png",
+                          "url": "/nav-icons/github.png",
                           "description": ""
                         }
                       },
@@ -188,7 +188,7 @@
                         "destination": "https://sentry.io/integrations/slack/",
                         "variant": "default",
                         "icon": {
-                          "url": "/astro-assets/nav-icons/slack.png",
+                          "url": "/nav-icons/slack.png",
                           "description": ""
                         }
                       },
@@ -326,7 +326,7 @@
         "title": "Bi-weekly Intro to Sentry Demo",
         "description": "See Sentry in action and learn how errors, performance issues, and context fit together to help you find bugs faster and ship with confidence. Join us bi-weekly on Thursdays!",
         "coverImage": {
-          "url": "/astro-assets/nav-icons/intro-demo.png",
+          "url": "/nav-icons/intro-demo.png",
           "description": "",
           "width": 1200,
           "height": 1200

--- a/src/lib/navigation/header.json
+++ b/src/lib/navigation/header.json
@@ -54,6 +54,14 @@
                 },
                 {
                   "__typename": "Button",
+                  "label": "Agent Tracing Menu Button",
+                  "cta": "Agent Tracing",
+                  "destination": "https://sentry.io/product/tracing/ai-agent/",
+                  "variant": "default",
+                  "class": "nested"
+                },
+                {
+                  "__typename": "Button",
                   "label": "Profiling Menu Button",
                   "cta": "Profiling",
                   "destination": "https://sentry.io/product/profiling/",
@@ -79,6 +87,15 @@
                   "cta": "Uptime Monitoring",
                   "destination": "https://sentry.io/product/uptime-monitoring/",
                   "variant": "default"
+                },
+                {
+                  "__typename": "Button",
+                  "label": "Labs Menu Button",
+                  "cta": "Labs",
+                  "destination": "https://labs.sentry.dev/",
+                  "variant": "default",
+                  "target": ["_blank"],
+                  "class": "new"
                 }
               ]
             }
@@ -114,7 +131,7 @@
                         "cta": "Agent",
                         "destination": "https://sentry.io/product/seer/agent/",
                         "variant": "default",
-                        "class": "new nested"
+                        "class": "nested"
                       },
                       {
                         "__typename": "Button",
@@ -122,7 +139,7 @@
                         "cta": "Autofix",
                         "destination": "https://sentry.io/product/seer/autofix/",
                         "variant": "default",
-                        "class": "new nested"
+                        "class": "nested"
                       },
                       {
                         "__typename": "Button",
@@ -130,7 +147,7 @@
                         "cta": "AI Code Review",
                         "destination": "https://sentry.io/product/seer/ai-code-review/",
                         "variant": "default",
-                        "class": "new nested"
+                        "class": "nested"
                       }
                     ]
                   }
@@ -160,7 +177,7 @@
                         "destination": "https://sentry.io/integrations/github/",
                         "variant": "default",
                         "icon": {
-                          "url": "/nav-icons/github.png",
+                          "url": "/astro-assets/nav-icons/github.png",
                           "description": ""
                         }
                       },
@@ -171,7 +188,7 @@
                         "destination": "https://sentry.io/integrations/slack/",
                         "variant": "default",
                         "icon": {
-                          "url": "/nav-icons/slack.png",
+                          "url": "/astro-assets/nav-icons/slack.png",
                           "description": ""
                         }
                       },
@@ -272,6 +289,13 @@
           },
           {
             "__typename": "Button",
+            "label": "OpenTelemetry Menu Button",
+            "cta": "OpenTelemetry",
+            "destination": "https://sentry.io/solutions/opentelemetry/",
+            "variant": "default"
+          },
+          {
+            "__typename": "Button",
             "label": "Enterprise Menu Button",
             "cta": "Enterprise",
             "destination": "https://sentry.io/for/enterprise/",
@@ -302,7 +326,7 @@
         "title": "Bi-weekly Intro to Sentry Demo",
         "description": "See Sentry in action and learn how errors, performance issues, and context fit together to help you find bugs faster and ship with confidence. Join us bi-weekly on Thursdays!",
         "coverImage": {
-          "url": "/nav-icons/intro-demo.png",
+          "url": "/astro-assets/nav-icons/intro-demo.png",
           "description": "",
           "width": 1200,
           "height": 1200
@@ -437,9 +461,9 @@
                     "items": [
                       {
                         "__typename": "Button",
-                        "label": "Build Menu Button",
-                        "cta": "Sentry Build",
-                        "destination": "https://sentry.io/resources/sentry-build/",
+                        "label": "Community Menu Button",
+                        "cta": "Community",
+                        "destination": "https://sentry.io/community/",
                         "variant": "default"
                       },
                       {


### PR DESCRIPTION
## Summary
- Syncs `header.json` from `getsentry/static-sites` to catch up with recent nav changes
- Covers all 5 open sync issues on static-sites (#4576, #4391, #4352, #4349, #4311)

Changes:
- Add Agent Tracing sub-item under Tracing
- Add Labs link (opens in new tab, marked as "new")
- Add OpenTelemetry under Solutions
- Fix nav icon asset paths (`/nav-icons/` → `/astro-assets/nav-icons/`)
- Remove "new" class from Seer sub-items (Agent, Autofix, AI Code Review)
- Rename "Sentry Build" → "Community"

## Test plan
- [ ] Verify changelog site header renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)